### PR TITLE
Avoid healthcheck error mail despite successfully stopping Docker container

### DIFF
--- a/ansible/healthcheck
+++ b/ansible/healthcheck
@@ -31,7 +31,7 @@ Error:
 end
 
 failed_services = out.lines.map {|line| JSON.parse(line) }.select {|service|
-  service['State'] == 'exited' && service['ExitCode'] != 0
+  service['State'] == 'exited' && (service['ExitCode'] != 0 || service['ExitCode'] != 143)
 }
 
 exit 0 if failed_services.empty?

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -36,6 +36,8 @@ services:
         OPENID_CONFIGURATION_ENDPOINT:
         RUBY_VERSION:
 
+    init: true
+
     environment:
       CURATOR_ML_ADDRESS:          '"DDBJ Mass Submission System (MSS)" <mass@ddbj.nig.ac.jp>'
       DATABASE_URL:                postgresql://postgres@postgres/mssform


### PR DESCRIPTION
If the exit code is 0 or 143 on `docker compose stop`, it means that the process has terminated successfully.

- https://komodor.com/learn/sigterm-signal-15-exit-code-143-linux-graceful-termination/#:~:text=Docker%20exit%20code%20143%20%E2%80%93%20means,by%20the%20underlying%20operating%20system