### PR TITLE
Precompile assets during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ COPY . .
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/
 
+# Precompile assets for mission_control-jobs (and anything else served via Propshaft)
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+
 FROM docker.io/library/node:24.14.1 AS web
 
 ARG RAILS_ENV


### PR DESCRIPTION
## Summary

- The mission_control-jobs dashboard added in #1361 renders unstyled on staging because `public/assets/` is never populated — the Dockerfile has no `assets:precompile` step.
- Run `bin/rails assets:precompile` in the build stage with `SECRET_KEY_BASE_DUMMY=1` so Propshaft's fingerprinted CSS/JS are present in the final image.

## Test plan

- [x] `SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bin/rails assets:precompile` — generates the exact filenames the browser is 404'ing on (`mission_control/jobs/application-6148a20a.css`, `bulma.min-ba74c9da.css`, etc.)
- [ ] After merge and redeploy to staging, `/admin/jobs` renders styled

🤖 Generated with [Claude Code](https://claude.com/claude-code)