### PR TITLE
Group @glint/* updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
     directory: /web
     schedule:
       interval: daily
+    groups:
+      # @glint/template and @glint/ember-tsc ship on separate release lines
+      # and are incompatible unless bumped together, so update them in a
+      # single PR.
+      glint:
+        patterns:
+          - '@glint/*'
     ignore:
       # Babel 8 requires the whole @babel/* graph to move together, but the
       # Ember build toolchain (ember-cli-babel, broccoli-babel-transpiler)


### PR DESCRIPTION
`@glint/template` (1.7.x) and `@glint/ember-tsc` (1.8.x) ship on separate release lines but are incompatible unless bumped together — a standalone bump of one breaks `ember-tsc --noEmit` type checking (this is what broke #1507). Grouping them into a single Dependabot PR prevents the mismatch from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)