### PR TITLE
Resolve frontend backend URLs relative to the serving origin

### DIFF
--- a/web/app/config/environment.ts
+++ b/web/app/config/environment.ts
@@ -21,5 +21,8 @@ export default config as {
   locationType: string;
   rootURL: string;
   APP: Record<string, unknown>;
+  appURL: string;
   apiURL: string;
+  authURL: string;
+  directUploadURL: string;
 } & Record<string, unknown>;

--- a/web/app/controllers/index.ts
+++ b/web/app/controllers/index.ts
@@ -3,5 +3,5 @@ import Controller from '@ember/controller';
 import ENV from 'mssform/config/environment';
 
 export default class IndexController extends Controller {
-  authURL = new URL('/auth/keycloak', ENV.apiURL).href;
+  authURL = ENV.authURL;
 }

--- a/web/app/models/upload-files.ts
+++ b/web/app/models/upload-files.ts
@@ -48,7 +48,7 @@ class UploadFile {
   perform(currentUser: CurrentUserService) {
     const upload = new DirectUpload(
       this.file.rawFile,
-      `${ENV.apiURL}/direct_uploads`,
+      ENV.directUploadURL,
       {
         directUploadWillCreateBlobWithXHR: (xhr: XMLHttpRequest) => {
           xhr.setRequestHeader('Authorization', `Bearer ${currentUser.token}`);

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -10,6 +10,18 @@ const app = yaml.load(fs.readFileSync(path.join(__dirname, '../../config/app.yml
 const enums = yaml.load(fs.readFileSync(path.join(__dirname, '../../config/enums.yml')));
 
 module.exports = function (environment) {
+  // Origin of the Rails backend, used as the base for every backend URL below.
+  //
+  // In production the built assets are served from the same origin as the API,
+  // so we leave this empty and let the URLs resolve relative to wherever the app
+  // is served. That keeps a single production image environment-agnostic, so it
+  // can be promoted across environments without the frontend pointing at the
+  // wrong backend.
+  //
+  // In development and test the Ember and Rails servers run on separate origins,
+  // so we use the absolute app_url from config/app.yml.
+  const appURL = environment === 'production' ? '' : app.app_url;
+
   const ENV = {
     modulePrefix: 'mssform',
     environment,
@@ -29,10 +41,14 @@ module.exports = function (environment) {
     },
 
     railsEnv,
-    apiURL: new URL('/api', app.app_url).href,
+    appURL,
     sentryDSN: app.sentry_dsn,
     enums,
   };
+
+  ENV.apiURL = `${appURL}/api`;
+  ENV.authURL = `${appURL}/auth/keycloak`;
+  ENV.directUploadURL = `${appURL}/api/direct_uploads`;
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;

--- a/web/tests/msw/handlers.ts
+++ b/web/tests/msw/handlers.ts
@@ -4,7 +4,7 @@ import ENV from 'mssform/config/environment';
 
 import { http } from './http';
 
-const directUploadURL = new URL('/api/direct_uploads', ENV.apiURL).toString();
+const directUploadURL = ENV.directUploadURL;
 
 export const handlers = [
   http.get('/me', ({ response }) => {
@@ -27,13 +27,13 @@ export const handlers = [
       signed_id: 'test-signed-id',
 
       direct_upload: {
-        url: `${ENV.apiURL}/rails/active_storage/disk/test`,
+        url: `${ENV.appURL}/rails/active_storage/disk/test`,
         headers: { 'Content-Type': 'application/octet-stream' },
       },
     });
   }),
 
-  mswHttp.put(`${ENV.apiURL}/rails/active_storage/disk/*`, () => {
+  mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, () => {
     return new HttpResponse(null, { status: 204 });
   }),
 ];


### PR DESCRIPTION
## Background

Mirrors ddbj/ddbj-repository#1912 for mssform.

The frontend baked an **absolute** backend URL into the build. `web/config/environment.js` set `apiURL = new URL('/api', app.app_url).href`, where `app.app_url` is read from `config/app.yml` keyed by the build-time `RAILS_ENV`. An image built for one environment therefore pointed the frontend at that environment's backend. Promoting a staging-built image to production (e.g. `kamal deploy -P`, which skips the build and reuses the existing image) made production's frontend talk to the staging backend, and login redirected to the staging IdP.

## Change

The built assets are served from the **same origin** as the API in production, so resolve backend URLs relative to the serving origin instead of baking in an absolute one.

- `web/config/environment.js` — compute a base `appURL`:
  - production: `''` (resolves relative to wherever the app is served)
  - development / test: the absolute `app_url` from `config/app.yml` (Ember and Rails run on separate origins)
  - derive `apiURL` / `authURL` / `directUploadURL` from it as template strings (`authURL` is new)
- Consumers that built these URLs inline now read the centralized `ENV.*`:
  - `web/app/controllers/index.ts` → `ENV.authURL` (also avoids `new URL('/auth/keycloak', '/api')` throwing on the relative production base)
  - `web/app/models/upload-files.ts` → `ENV.directUploadURL`
  - `web/tests/msw/handlers.ts` → `ENV.directUploadURL`
- `web/app/config/environment.ts` — add the new type fields
- Fix the MSW mock to mount the Active Storage disk endpoint at the Rails root (`${appURL}/rails/active_storage/disk/...`), matching where Rails actually serves it, rather than under `/api`

Dev/test URL values are byte-for-byte identical to before; only production switches to relative.

### Note on `RAILS_ENV` build arg

Unlike ddbj-repository (which removed an `APP_URL`-only build arg), mssform's `RAILS_ENV` build arg is still needed: `environment.js` also uses it to select the `sentry_dsn` / `railsEnv` Sentry tag from `app.yml`. It is left in place. The Sentry `environment` tag therefore still reflects the build-time `RAILS_ENV` (currently moot — no `sentry_dsn` is configured, so `Sentry.init` never runs).

## Tests

- `cd web && pnpm lint` ✅
- `cd web && pnpm test` ✅ (24 pass)
- `/code-review` (high effort) — 0 correctness findings; the one cleanup finding (the Active Storage mock path) is addressed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)