### PR TITLE
Add GGS (Gene/genome submission tool) job import

### DIFF
--- a/app/controllers/ggs_extractions_controller.rb
+++ b/app/controllers/ggs_extractions_controller.rb
@@ -1,0 +1,13 @@
+class GgsExtractionsController < ApplicationController
+  def show
+    @extraction = current_user.ggs_extractions.find(params[:id])
+  end
+
+  def create
+    @extraction = current_user.ggs_extractions.create!(ggs_job_ids: params[:ids])
+
+    ExtractMetadataJob.perform_later @extraction
+
+    render 'show', status: :created
+  end
+end

--- a/app/jobs/extract_metadata_job.rb
+++ b/app/jobs/extract_metadata_job.rb
@@ -3,7 +3,7 @@ class ExtractMetadataJob < ApplicationJob
     ActiveRecord::Base.transaction do
       begin
         extraction.prepare_files
-      rescue DfastExtraction::ExtractionError => e
+      rescue Extraction::Error => e
         extraction.update! state: 'rejected', error: {id: e.id, **e.data}
         return
       end

--- a/app/models/concerns/extraction.rb
+++ b/app/models/concerns/extraction.rb
@@ -1,0 +1,33 @@
+module Extraction
+  extend ActiveSupport::Concern
+
+  class Error < StandardError
+    def initialize(id, **data)
+      super()
+
+      @id   = id
+      @data = data
+    end
+
+    attr_reader :id, :data
+  end
+
+  included do
+    belongs_to :user
+
+    has_many :files, dependent: :destroy, class_name: "#{name}File", foreign_key: :extraction_id
+  end
+
+  def working_dir
+    dir  = Rails.application.config_for(:app).extracts_dir!
+    name = self.class.name.delete_suffix('Extraction').underscore.dasherize
+
+    Pathname.new(dir).join("#{name}-#{id}")
+  end
+
+  private
+
+  def normalize_path(path)
+    path.to_s.gsub(%r{[/ ]}, '/' => '__', ' ' => '_')
+  end
+end

--- a/app/models/concerns/extraction_upload.rb
+++ b/app/models/concerns/extraction_upload.rb
@@ -1,0 +1,21 @@
+module ExtractionUpload
+  extend ActiveSupport::Concern
+
+  include UploadVia
+
+  class_methods do
+    def from_params(extraction_id:, **)
+      new(extraction_id:)
+    end
+  end
+
+  def copy_files_to_submissions_dir
+    upload.files_dir.mkpath
+
+    extraction.files.find_each do |file|
+      FileUtils.cp file.fullpath, upload.files_dir
+    end
+
+    trim_annotation_fields!
+  end
+end

--- a/app/models/dfast_extraction.rb
+++ b/app/models/dfast_extraction.rb
@@ -1,16 +1,5 @@
 class DfastExtraction < ApplicationRecord
-  class ExtractionError < StandardError
-    def initialize(id, **data)
-      @id   = id
-      @data = data
-    end
-
-    attr_reader :id, :data
-  end
-
-  belongs_to :user
-
-  has_many :files, dependent: :destroy, class_name: 'DfastExtractionFile', foreign_key: :extraction_id
+  include Extraction
 
   validates :dfast_job_ids, presence: true
 
@@ -24,18 +13,12 @@ class DfastExtraction < ApplicationRecord
     end
   end
 
-  def working_dir
-    dir = Rails.application.config_for(:app).extracts_dir!
-
-    Pathname.new(dir).join("dfast-#{id}")
-  end
-
   private
 
   def fetch_and_copy_files(job_id)
     res = Fetch::API.fetch("https://dfast.ddbj.nig.ac.jp/analysis/download/#{job_id}/ddbj_submission.zip")
 
-    raise ExtractionError.new(:failed_to_fetch, job_id:, reason: "#{res.status} #{res.status_text}") unless res.ok
+    raise Extraction::Error.new(:failed_to_fetch, job_id:, reason: "#{res.status} #{res.status_text}") unless res.ok
 
     zip = Zip::InputStream.new(StringIO.new(res.body))
 
@@ -54,9 +37,5 @@ class DfastExtraction < ApplicationRecord
         )
       end
     end
-  end
-
-  def normalize_path(path)
-    path.to_s.gsub(%r{[/ ]}, '/' => '__', ' ' => '_')
   end
 end

--- a/app/models/dfast_upload.rb
+++ b/app/models/dfast_upload.rb
@@ -1,21 +1,7 @@
 class DfastUpload < ApplicationRecord
-  include UploadVia
+  include ExtractionUpload
 
   belongs_to :extraction, class_name: 'DfastExtraction'
 
-  delegate :dfast_job_ids, to: :extraction
-
-  def self.from_params(extraction_id:, **)
-    new(extraction_id:)
-  end
-
-  def copy_files_to_submissions_dir
-    upload.files_dir.mkpath
-
-    extraction.files.find_each do |file|
-      FileUtils.cp file.fullpath, upload.files_dir
-    end
-
-    trim_annotation_fields!
-  end
+  def job_ids = extraction.dfast_job_ids
 end

--- a/app/models/ggs_extraction.rb
+++ b/app/models/ggs_extraction.rb
@@ -1,0 +1,56 @@
+class GgsExtraction < ApplicationRecord
+  include Extraction
+
+  EXTENSIONS = %w[ann fa].freeze
+
+  UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
+  validates :ggs_job_ids, presence: true
+
+  validate do
+    next if ggs_job_ids.blank?
+
+    errors.add :ggs_job_ids, :invalid unless ggs_job_ids.all? { _1.match?(UUID_FORMAT) }
+  end
+
+  def prepare_files
+    working_dir.mkpath
+
+    ActiveRecord::Base.transaction do
+      ggs_job_ids.uniq.each do |job_id|
+        copy_files job_id
+      end
+    end
+  end
+
+  private
+
+  def copy_files(job_id)
+    src_dir = job_output_dir(job_id)
+
+    raise Extraction::Error.new(:directory_not_found, job_id:) unless src_dir.directory?
+
+    dest_dir = working_dir.join(job_id).tap(&:mkpath)
+
+    Pathname.glob("*.{#{EXTENSIONS.join(',')}}", base: src_dir).each do |rel|
+      name = normalize_path(rel)
+
+      FileUtils.cp src_dir.join(rel), dest_dir.join(name)
+
+      files.create!(
+        name:,
+        parsing:    true,
+        ggs_job_id: job_id
+      )
+    end
+  end
+
+  def job_output_dir(job_id)
+    template = Rails.application.config_for(:app).ggs_jobs_dir_template!
+    path     = template.gsub('{job_id}', job_id)
+
+    raise "malformed directory path: #{path}" unless path == File.expand_path(path)
+
+    Pathname.new(path)
+  end
+end

--- a/app/models/ggs_extraction_file.rb
+++ b/app/models/ggs_extraction_file.rb
@@ -1,0 +1,7 @@
+class GgsExtractionFile < ApplicationRecord
+  include ExtractionFile
+
+  belongs_to :extraction, class_name: 'GgsExtraction'
+
+  def fullpath = extraction.working_dir.join(ggs_job_id, name)
+end

--- a/app/models/ggs_upload.rb
+++ b/app/models/ggs_upload.rb
@@ -1,0 +1,7 @@
+class GgsUpload < ApplicationRecord
+  include ExtractionUpload
+
+  belongs_to :extraction, class_name: 'GgsExtraction'
+
+  def job_ids = extraction.ggs_job_ids
+end

--- a/app/models/mass_directory_extraction.rb
+++ b/app/models/mass_directory_extraction.rb
@@ -9,6 +9,8 @@ using Module.new {
 }
 
 class MassDirectoryExtraction < ApplicationRecord
+  include Extraction
+
   ARCHIVE_EXT = %w[zip tar tar.gz tgz taz tar.Z taZ tar.bz2 tz2 tbz2 tbz tar.lz tar.lzma tlz tar.lzo tar.xz tar.zst tzst]
 
   COMPRESS = {
@@ -24,20 +26,10 @@ class MassDirectoryExtraction < ApplicationRecord
 
   COMPRESS_EXT = ExtractionFile::FILE_EXT.product(COMPRESS.keys).map { "#{_1}.#{_2}" }
 
-  belongs_to :user
-
-  has_many :files, dependent: :destroy, class_name: 'MassDirectoryExtractionFile', foreign_key: :extraction_id
-
   def prepare_files
     ActiveRecord::Base.transaction do
       unarchive_and_copy_files user_mass_dir
     end
-  end
-
-  def working_dir
-    dir = Rails.application.config_for(:app).extracts_dir!
-
-    Pathname.new(dir).join("mass-directory-#{id}")
   end
 
   private
@@ -96,9 +88,5 @@ class MassDirectoryExtraction < ApplicationRecord
       name:    dest,
       parsing: true
     )
-  end
-
-  def normalize_path(path)
-    path.to_s.gsub(%r{[/ ]}, '/' => '__', ' ' => '_')
   end
 end

--- a/app/models/mass_directory_upload.rb
+++ b/app/models/mass_directory_upload.rb
@@ -1,23 +1,7 @@
 class MassDirectoryUpload < ApplicationRecord
-  include UploadVia
+  include ExtractionUpload
 
   belongs_to :extraction, class_name: 'MassDirectoryExtraction'
 
-  def self.from_params(extraction_id:, **)
-    new(extraction_id:)
-  end
-
-  def copy_files_to_submissions_dir
-    upload.files_dir.mkpath
-
-    extraction.files.find_each do |file|
-      FileUtils.cp file.fullpath, upload.files_dir
-    end
-
-    trim_annotation_fields!
-  end
-
-  def dfast_job_ids
-    nil
-  end
+  def job_ids = nil
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -2,7 +2,8 @@ class Upload < ApplicationRecord
   VIA = {
     webui:          'WebuiUpload',
     dfast:          'DfastUpload',
-    mass_directory: 'MassDirectoryUpload'
+    mass_directory: 'MassDirectoryUpload',
+    ggs:            'GgsUpload'
   }
 
   def self.find_via(ident)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :submissions,                dependent: :destroy
   has_many :dfast_extractions,          dependent: :destroy
   has_many :mass_directory_extractions, dependent: :destroy
+  has_many :ggs_extractions,            dependent: :destroy
 
   def token
     JWT.encode({user_id: id}, Rails.application.secret_key_base, 'HS512')

--- a/app/models/webui_upload.rb
+++ b/app/models/webui_upload.rb
@@ -31,7 +31,5 @@ class WebuiUpload < ApplicationRecord
     update! copied: true, files: []
   end
 
-  def dfast_job_ids
-    nil
-  end
+  def job_ids = nil
 end

--- a/app/views/ggs_extractions/_file.json.jb
+++ b/app/views/ggs_extractions/_file.json.jb
@@ -1,0 +1,11 @@
+{
+  name:             file.name,
+  basename:         file.basename,
+  size:             file.size,
+  isParsing:        file.parsing?,
+  parsedData:       file.parsed_data,
+  isParseSucceeded: !!file.parsed_data,
+  errors:           file._errors,
+  fileType:         file.file_type,
+  jobId:            file.ggs_job_id
+}

--- a/app/views/ggs_extractions/show.json.jb
+++ b/app/views/ggs_extractions/show.json.jb
@@ -1,0 +1,7 @@
+{
+  _self: ggs_extraction_url(@extraction),
+  id:    @extraction.id,
+  state: @extraction.state,
+  error: @extraction.error,
+  files: render(partial: 'file', collection: @extraction.files)
+}

--- a/app/views/submissions/_submission.json.jb
+++ b/app/views/submissions/_submission.json.jb
@@ -9,10 +9,10 @@ state = working_list_states[submission.mass_id]
 
   uploads: submission.uploads.map {|upload|
     {
-      id:            upload.id,
-      created_at:    upload.created_at.iso8601,
-      files:         Dir.glob('*.*', base: upload.files_dir),
-      dfast_job_ids: upload.via.dfast_job_ids || []
+      id:         upload.id,
+      created_at: upload.created_at.iso8601,
+      files:      Dir.glob('*.*', base: upload.files_dir),
+      job_ids:    upload.via.job_ids || []
     }
   }
 }

--- a/config/app.yml
+++ b/config/app.yml
@@ -1,6 +1,7 @@
 development:
   app_url:                http://mssform.localhost:3000
   extracts_dir:           <%= Rails.root.join("storage/extracts") %>
+  ggs_jobs_dir_template:  <%= Rails.root.join("storage/ggs/{job_id}/output") %>
   mass_dir_path_template: <%= Rails.root.join("storage/mass/{user}") %>
   submissions_dir:        <%= Rails.root.join("storage/submissions") %>
   upload_events_log:      <%= Rails.root.join("storage/upload_events.jsonl") %>
@@ -9,6 +10,7 @@ development:
 test:
   app_url:                http://mssform.example.com:3000
   extracts_dir:           <%= Rails.root.join("tmp/storage/extracts") %>
+  ggs_jobs_dir_template:  <%= Rails.root.join("tmp/storage/ggs/{job_id}/output") %>
   mass_dir_path_template: <%= Rails.root.join("tmp/storage/mass/{user}") %>
   submissions_dir:        <%= Rails.root.join("tmp/storage/submissions") %>
   upload_events_log:      <%= Rails.root.join("tmp/storage/upload_events.jsonl") %>
@@ -17,6 +19,7 @@ test:
 production: &production
   app_url:                https://mss.ddbj.nig.ac.jp
   extracts_dir:           <%= Rails.root.join("storage/extracts") %>
+  ggs_jobs_dir_template:  /lustre9/open/home/w3dfast/ggs_volumes/jobs/{job_id}/output
   mass_dir_path_template: /submission/{user}/submission/{user}/mass
   submissions_dir:        <%= Rails.root.join("storage/submissions") %>
   upload_events_log:      <%= Rails.root.join("storage/upload_events.jsonl") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
     resources :dfast_extractions,          only: %i[show create]
     resources :mass_directory_extractions, only: %i[show create]
+    resources :ggs_extractions,            only: %i[show create]
 
     resources :direct_uploads, only: :create
   end

--- a/db/migrate/20260628030629_create_ggs_extractions_and_uploads.rb
+++ b/db/migrate/20260628030629_create_ggs_extractions_and_uploads.rb
@@ -1,0 +1,32 @@
+class CreateGgsExtractionsAndUploads < ActiveRecord::Migration[8.1]
+  def change
+    create_table :ggs_extractions do |t|
+      t.references :user, null: false
+
+      t.enum   :state, null: false, default: :pending, enum_type: :extraction_state
+      t.string :ggs_job_ids, array: true, null: false
+      t.jsonb  :error
+
+      t.timestamps
+    end
+
+    create_table :ggs_extraction_files do |t|
+      t.references :extraction, null: false, foreign_key: {to_table: :ggs_extractions}
+
+      t.string  :name,       null: false
+      t.string  :ggs_job_id, null: false
+
+      t.boolean :parsing,    null: false
+      t.jsonb   :parsed_data
+      t.jsonb   :_errors
+
+      t.index %i[extraction_id ggs_job_id name], unique: true
+    end
+
+    create_table :ggs_uploads do |t|
+      t.references :extraction, foreign_key: {to_table: :ggs_extractions}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_04_09_122233) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_28_030629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -82,6 +82,34 @@ ActiveRecord::Schema[8.1].define(version: 2025_04_09_122233) do
     t.bigint "extraction_id"
     t.datetime "updated_at", null: false
     t.index ["extraction_id"], name: "index_dfast_uploads_on_extraction_id"
+  end
+
+  create_table "ggs_extraction_files", force: :cascade do |t|
+    t.jsonb "_errors"
+    t.bigint "extraction_id", null: false
+    t.string "ggs_job_id", null: false
+    t.string "name", null: false
+    t.jsonb "parsed_data"
+    t.boolean "parsing", null: false
+    t.index ["extraction_id", "ggs_job_id", "name"], name: "idx_on_extraction_id_ggs_job_id_name_dc6e405a2b", unique: true
+    t.index ["extraction_id"], name: "index_ggs_extraction_files_on_extraction_id"
+  end
+
+  create_table "ggs_extractions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.jsonb "error"
+    t.string "ggs_job_ids", null: false, array: true
+    t.enum "state", default: "pending", null: false, enum_type: "extraction_state"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_ggs_extractions_on_user_id"
+  end
+
+  create_table "ggs_uploads", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "extraction_id"
+    t.datetime "updated_at", null: false
+    t.index ["extraction_id"], name: "index_ggs_uploads_on_extraction_id"
   end
 
   create_table "mass_directory_extraction_files", force: :cascade do |t|
@@ -164,6 +192,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_04_09_122233) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "dfast_extraction_files", "dfast_extractions", column: "extraction_id"
   add_foreign_key "dfast_uploads", "dfast_extractions", column: "extraction_id"
+  add_foreign_key "ggs_extraction_files", "ggs_extractions", column: "extraction_id"
+  add_foreign_key "ggs_uploads", "ggs_extractions", column: "extraction_id"
   add_foreign_key "mass_directory_extraction_files", "mass_directory_extractions", column: "extraction_id"
   add_foreign_key "mass_directory_uploads", "mass_directory_extractions", column: "extraction_id"
 end

--- a/schema/openapi.d.ts
+++ b/schema/openapi.d.ts
@@ -89,9 +89,9 @@ export interface paths {
                         submission: {
                             tpa: boolean;
                             /** @enum {string} */
-                            upload_via: "webui" | "dfast" | "mass_directory";
+                            upload_via: "webui" | "dfast" | "mass_directory" | "ggs";
                             files?: string[];
-                            /** @description Extraction ID (for dfast or mass_directory upload) */
+                            /** @description Extraction ID (for dfast, mass_directory, or ggs upload) */
                             extraction_id?: number;
                             entries_count: number;
                             /** Format: date */
@@ -259,9 +259,9 @@ export interface paths {
                     "application/json": {
                         upload: {
                             /** @enum {string} */
-                            via: "webui" | "dfast" | "mass_directory";
+                            via: "webui" | "dfast" | "mass_directory" | "ggs";
                             files?: string[];
-                            /** @description Extraction ID (for dfast or mass_directory upload) */
+                            /** @description Extraction ID (for dfast, mass_directory, or ggs upload) */
                             extraction_id?: number;
                         };
                     };
@@ -269,7 +269,7 @@ export interface paths {
             };
             responses: {
                 /** @description Upload accepted. */
-                200: {
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -447,6 +447,90 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/ggs_extractions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Create a GGS extraction. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        ids: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Returns the created extraction. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GgsExtraction"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                422: components["responses"]["UnprocessableContent"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ggs_extractions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Get a GGS extraction. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Returns the requested extraction. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["GgsExtraction"];
+                    };
+                };
+                401: components["responses"]["Unauthorized"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -464,7 +548,7 @@ export interface components {
             /** Format: date-time */
             created_at: string;
             files: string[];
-            dfast_job_ids: string[];
+            job_ids: string[];
         };
         DfastExtraction: {
             /** Format: uri */
@@ -514,6 +598,30 @@ export interface components {
             errors: components["schemas"]["ExtractionFileError"][] | null;
             /** @enum {string} */
             fileType: "annotation" | "sequence";
+        };
+        GgsExtraction: {
+            /** Format: uri */
+            _self: string;
+            id: number;
+            state: components["schemas"]["ExtractionState"];
+            error: {
+                id: string;
+                job_id?: string;
+                reason?: string;
+            } | null;
+            files: components["schemas"]["GgsExtractionFile"][];
+        };
+        GgsExtractionFile: {
+            name: string;
+            basename: string;
+            size: number;
+            isParsing: boolean;
+            parsedData: components["schemas"]["ParsedData"] | null;
+            isParseSucceeded: boolean;
+            errors: components["schemas"]["ExtractionFileError"][] | null;
+            /** @enum {string} */
+            fileType: "annotation" | "sequence";
+            jobId: string;
         };
         ParsedData: {
             contactPerson?: {

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -102,7 +102,7 @@ paths:
 
                     upload_via:
                       type: string
-                      enum: [webui, dfast, mass_directory]
+                      enum: [webui, dfast, mass_directory, ggs]
 
                     files:
                       type: array
@@ -113,7 +113,7 @@ paths:
 
                     extraction_id:
                       type: integer
-                      description: Extraction ID (for dfast or mass_directory upload)
+                      description: Extraction ID (for dfast, mass_directory, or ggs upload)
 
                     entries_count:
                       type: integer
@@ -350,7 +350,7 @@ paths:
                   properties:
                     via:
                       type: string
-                      enum: [webui, dfast, mass_directory]
+                      enum: [webui, dfast, mass_directory, ggs]
 
                     files:
                       type: array
@@ -361,7 +361,7 @@ paths:
 
                     extraction_id:
                       type: integer
-                      description: Extraction ID (for dfast or mass_directory upload)
+                      description: Extraction ID (for dfast, mass_directory, or ggs upload)
 
       responses:
         '204':
@@ -495,6 +495,76 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /ggs_extractions:
+    post:
+      description: Create a GGS extraction.
+
+      tags:
+        - Extractions
+
+      requestBody:
+        required: true
+
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [ids]
+
+              properties:
+                ids:
+                  type: array
+
+                  items:
+                    type: string
+                    description: GGS job ID
+
+      responses:
+        '201':
+          description: Returns the created extraction.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GgsExtraction'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+
+  /ggs_extractions/{id}:
+    get:
+      description: Get a GGS extraction.
+
+      tags:
+        - Extractions
+
+      parameters:
+        - name: id
+          in: path
+          required: true
+
+          schema:
+            type: integer
+
+      responses:
+        '200':
+          description: Returns the requested extraction.
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GgsExtraction'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
 components:
   schemas:
     Submission:
@@ -541,7 +611,7 @@ components:
         - id
         - created_at
         - files
-        - dfast_job_ids
+        - job_ids
 
       properties:
         id:
@@ -557,7 +627,7 @@ components:
           items:
             type: string
 
-        dfast_job_ids:
+        job_ids:
           type: array
 
           items:
@@ -756,6 +826,103 @@ components:
         fileType:
           type: string
           enum: [annotation, sequence]
+
+    GgsExtraction:
+      type: object
+      additionalProperties: false
+
+      required:
+        - _self
+        - id
+        - state
+        - error
+        - files
+
+      properties:
+        _self:
+          type: string
+          format: uri
+
+        id:
+          type: integer
+
+        state:
+          $ref: '#/components/schemas/ExtractionState'
+
+        error:
+          type:
+            - object
+            - 'null'
+
+          additionalProperties: false
+          required: [id]
+
+          properties:
+            id:
+              type: string
+
+            job_id:
+              type: string
+
+            reason:
+              type: string
+
+        files:
+          type: array
+
+          items:
+            $ref: '#/components/schemas/GgsExtractionFile'
+
+    GgsExtractionFile:
+      type: object
+      additionalProperties: false
+
+      required:
+        - name
+        - basename
+        - size
+        - isParsing
+        - parsedData
+        - isParseSucceeded
+        - errors
+        - fileType
+        - jobId
+
+      properties:
+        name:
+          type: string
+
+        basename:
+          type: string
+
+        size:
+          type: integer
+
+        isParsing:
+          type: boolean
+
+        parsedData:
+          anyOf:
+            - $ref: '#/components/schemas/ParsedData'
+            - type: 'null'
+
+        isParseSucceeded:
+          type: boolean
+
+        errors:
+          type:
+            - array
+            - 'null'
+
+          items:
+            $ref: '#/components/schemas/ExtractionFileError'
+
+        fileType:
+          type: string
+          enum: [annotation, sequence]
+
+        jobId:
+          type: string
 
     ParsedData:
       type: object

--- a/test/fixtures/ggs_extractions.yml
+++ b/test/fixtures/ggs_extractions.yml
@@ -1,0 +1,4 @@
+alice_ggs_extraction:
+  user:        alice
+  ggs_job_ids: '{01234567-89ab-cdef-0000-000000000001}'
+  state:       pending

--- a/test/integration/ggs_extractions_test.rb
+++ b/test/integration/ggs_extractions_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class GgsExtractionsTest < ActionDispatch::IntegrationTest
+  setup do
+    default_headers['Authorization'] = "Bearer #{users(:alice).token}"
+  end
+
+  test 'create' do
+    post '/api/ggs_extractions', params: {
+      ids: ['01234567-89ab-cdef-0000-000000000001']
+    }, as: :json
+
+    assert_conform_schema 201
+  end
+
+  test 'show' do
+    get "/api/ggs_extractions/#{ggs_extractions(:alice_ggs_extraction).id}"
+
+    assert_conform_schema 200
+  end
+end

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+class GgsExtractionTest < ActiveSupport::TestCase
+  setup do
+    base = Rails.application.config_for(:app).ggs_jobs_dir_template!.split('{job_id}').first
+
+    FileUtils.rm_rf base
+  end
+
+  def output_dir(job_id)
+    Rails.application.config_for(:app).ggs_jobs_dir_template!.gsub('{job_id}', job_id).then {|path|
+      Pathname.new(path).tap(&:mkpath)
+    }
+  end
+
+  test 'prepare_files copies .ann/.fa pairs and tags them with the job ID' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+
+    dir.join('foo.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    dir.join('foo.fa').write  ">CLN01\nACGT\n"
+    dir.join('readme.txt').write 'ignored'
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+    extraction.prepare_files
+
+    files = extraction.files.order(:name)
+
+    assert_equal %w[foo.ann foo.fa], files.map(&:name)
+    assert_equal [job_id, job_id],   files.map(&:ggs_job_id)
+    assert files.all? { _1.fullpath.exist? }
+  end
+
+  test 'prepare_files keeps files from different jobs separate' do
+    job1 = '01234567-89ab-cdef-0000-000000000001'
+    job2 = '01234567-89ab-cdef-0000-000000000002'
+
+    [job1, job2].each do |job_id|
+      dir = output_dir(job_id)
+
+      dir.join('genome.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+      dir.join('genome.fa').write  ">CLN01\nACGT\n"
+    end
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job1, job2])
+    extraction.prepare_files
+
+    assert_equal 4, extraction.files.count
+    assert_equal [job1, job1, job2, job2], extraction.files.order(:ggs_job_id, :name).map(&:ggs_job_id)
+  end
+
+  test 'prepare_files raises when the job output directory is missing' do
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: ['01234567-89ab-cdef-0000-000000000099'])
+
+    error = assert_raises Extraction::Error do
+      extraction.prepare_files
+    end
+
+    assert_equal :directory_not_found, error.id
+  end
+
+  test 'prepare_files processes a duplicated job ID only once' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+
+    dir.join('foo.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    dir.join('foo.fa').write  ">CLN01\nACGT\n"
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id, job_id])
+    extraction.prepare_files
+
+    assert_equal %w[foo.ann foo.fa], extraction.files.order(:name).map(&:name)
+  end
+
+  test 'rejects non-UUID job IDs' do
+    extraction = GgsExtraction.new(user: users(:alice), ggs_job_ids: ['not-a-uuid'])
+
+    assert_not extraction.valid?
+    assert_includes extraction.errors[:ggs_job_ids], 'is invalid'
+  end
+
+  test 'rejects blank job IDs without raising' do
+    extraction = GgsExtraction.new(user: users(:alice), ggs_job_ids: nil)
+
+    assert_not extraction.valid?
+    assert_includes extraction.errors[:ggs_job_ids], "can't be blank"
+  end
+end

--- a/web/app/components/ggs-extractor.gts
+++ b/web/app/components/ggs-extractor.gts
@@ -7,25 +7,25 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
-import DfastExtractorItem from 'mssform/components/dfast-extractor/item';
+import GgsExtractorItem from 'mssform/components/ggs-extractor/item';
 import errorsFor from 'mssform/helpers/errors-for';
 import totalFileSize from 'mssform/helpers/total-file-size';
-import DfastExtraction from 'mssform/models/dfast-extraction';
+import GgsExtraction from 'mssform/models/ggs-extraction';
 
 import type { components } from 'schema/openapi';
 import type ErrorModalService from 'mssform/services/error-modal';
 import type { SubmissionFileData, SubmissionError } from 'mssform/models/submission-file';
 
-type DfastExtractionPayload = components['schemas']['DfastExtraction'];
+type GgsExtractionPayload = components['schemas']['GgsExtraction'];
 
 export interface Signature {
   Args: {
-    onPoll: (payload: DfastExtractionPayload) => void;
+    onPoll: (payload: GgsExtractionPayload) => void;
     crossoverErrors: Map<SubmissionFileData, SubmissionError[]>;
   };
 }
 
-export default class DfastExtractorComponent extends Component<Signature> {
+export default class GgsExtractorComponent extends Component<Signature> {
   @service declare errorModal: ErrorModalService;
 
   @tracked jobIdsText = '';
@@ -61,7 +61,7 @@ export default class DfastExtractorComponent extends Component<Signature> {
     this.files = [];
 
     try {
-      const extraction = await DfastExtraction.create(getOwner(this)!, this.jobIds);
+      const extraction = await GgsExtraction.create(getOwner(this)!, this.jobIds);
 
       await extraction.pollForResult(
         (payload) => {
@@ -87,9 +87,9 @@ export default class DfastExtractorComponent extends Component<Signature> {
       <form class="card-body" {{on "submit" this.extract}}>
         <div class="mb-3">
           {{#let (uniqueId) as |id|}}
-            <label for={{id}} class="form-label">{{t "dfast-extractor.ids-label"}}</label>
+            <label for={{id}} class="form-label">{{t "ggs-extractor.ids-label"}}</label>
 
-            <div class="form-text">{{t "dfast-extractor.ids-help-html" htmlSafe=true}}</div>
+            <div class="form-text">{{t "ggs-extractor.ids-help-html" htmlSafe=true}}</div>
 
             <textarea
               rows={{6}}
@@ -104,7 +104,7 @@ export default class DfastExtractorComponent extends Component<Signature> {
         </div>
 
         <button type="submit" class="btn btn-primary" disabled={{this.extracting}}>
-          {{t "dfast-extractor.submit"}}
+          {{t "ggs-extractor.submit"}}
         </button>
 
         {{#if this.extracting}}
@@ -117,7 +117,7 @@ export default class DfastExtractorComponent extends Component<Signature> {
       {{#if this.files.length}}
         <ul class="list-group list-group-flush overflow-auto" style="max-height: 550px">
           {{#each this.sortedFiles key="name" as |file|}}
-            <DfastExtractorItem @file={{file}} @errors={{errorsFor file @crossoverErrors}} />
+            <GgsExtractorItem @file={{file}} @errors={{errorsFor file @crossoverErrors}} />
           {{/each}}
         </ul>
 

--- a/web/app/components/ggs-extractor/item.gts
+++ b/web/app/components/ggs-extractor/item.gts
@@ -1,0 +1,17 @@
+import SubmissionFileItem from 'mssform/components/submission-file-item';
+
+import type { TOC } from '@ember/component/template-only';
+import type { SubmissionFileData, SubmissionError } from 'mssform/models/submission-file';
+
+interface Signature {
+  Args: {
+    file: SubmissionFileData;
+    errors: SubmissionError[];
+  };
+}
+
+<template>
+  <SubmissionFileItem @file={{@file}} @errors={{@errors}}>
+    <:prefix>{{@file.jobId}}/</:prefix>
+  </SubmissionFileItem>
+</template> satisfies TOC<Signature>;

--- a/web/app/components/recent-submissions.gts
+++ b/web/app/components/recent-submissions.gts
@@ -13,8 +13,8 @@ import type { RequestManager } from '@warp-drive/core';
 
 type Submission = components['schemas']['Submission'];
 
-function dfastJobIds(submission: Submission): string[] {
-  return submission.uploads[0]?.dfast_job_ids ?? [];
+function submissionJobIds(submission: Submission): string[] {
+  return submission.uploads[0]?.job_ids ?? [];
 }
 
 function take<T>(n: number, arr: T[]): T[] {
@@ -55,7 +55,7 @@ export default class RecentSubmissions extends Component {
           <tr>
             <th>Mass ID</th>
             <th>Submission Date</th>
-            <th>DFAST Job IDs</th>
+            <th>Job IDs</th>
             <th>Status</th>
             <th>Accession</th>
           </tr>
@@ -73,7 +73,7 @@ export default class RecentSubmissions extends Component {
               </td>
 
               <td>
-                {{#let (dfastJobIds submission) as |jobIds|}}
+                {{#let (submissionJobIds submission) as |jobIds|}}
                   <ul class="list-unstyled m-0">
                     {{#each (take 3 jobIds) as |jobId|}}
                       <li><code>{{jobId}}</code></li>

--- a/web/app/components/submission-form/files.gts
+++ b/web/app/components/submission-form/files.gts
@@ -10,6 +10,7 @@ import svgJar from 'ember-svg-jar/helpers/svg-jar';
 
 import DfastExtractor from 'mssform/components/dfast-extractor';
 import FileList from 'mssform/components/file-list';
+import GgsExtractor from 'mssform/components/ggs-extractor';
 import SupportedFileTypes from 'mssform/components/file-list/supported-file-types';
 import MassDirectoryExtractor from 'mssform/components/mass-directory-extractor';
 import RadioGroup from 'mssform/components/radio-group';
@@ -181,6 +182,21 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
               <div class="form-check">
                 <group.radio as |radio|>
                   <radio.input
+                    checked={{eq @model.uploadVia "ggs"}}
+                    required
+                    class="form-check-input"
+                    {{on "change" (fn this.setUploadVia "ggs")}}
+                  />
+
+                  <radio.label class="form-check-label">
+                    {{t "submission-form.files.a4"}}
+                  </radio.label>
+                </group.radio>
+              </div>
+
+              <div class="form-check">
+                <group.radio as |radio|>
+                  <radio.input
                     checked={{eq @model.uploadVia "webui"}}
                     required
                     class="form-check-input"
@@ -224,6 +240,8 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
 
         {{#if (eq @model.uploadVia "dfast")}}
           <DfastExtractor @onPoll={{this.onExtractProgress}} @crossoverErrors={{this.crossoverErrors}} />
+        {{else if (eq @model.uploadVia "ggs")}}
+          <GgsExtractor @onPoll={{this.onExtractProgress}} @crossoverErrors={{this.crossoverErrors}} />
         {{else if (eq @model.uploadVia "webui")}}
           <div class="card">
             <div class="card-body">

--- a/web/app/models/ggs-extraction.ts
+++ b/web/app/models/ggs-extraction.ts
@@ -1,0 +1,63 @@
+import { service } from '@ember/service';
+import { setOwner } from '@ember/owner';
+
+import type { components } from 'schema/openapi';
+import type Owner from '@ember/owner';
+import type { RequestManager } from '@warp-drive/core';
+
+type GgsExtractionPayload = components['schemas']['GgsExtraction'];
+
+export default class GgsExtraction {
+  static async create(owner: Owner, ids: string[]) {
+    const requestManager = owner.lookup('service:request-manager') as RequestManager;
+
+    const { content } = await requestManager.request<GgsExtractionPayload>({
+      url: '/ggs_extractions',
+      method: 'POST',
+      data: { ids },
+    });
+
+    return new GgsExtraction(owner, content._self);
+  }
+
+  @service declare requestManager: RequestManager;
+
+  url: string;
+
+  constructor(owner: Owner, url: string) {
+    setOwner(this, owner);
+
+    this.url = url;
+  }
+
+  async pollForResult(
+    callback: (payload: GgsExtractionPayload) => void,
+    onError: (error: NonNullable<GgsExtractionPayload['error']>) => void,
+    signal?: AbortSignal,
+  ) {
+    for (;;) {
+      signal?.throwIfAborted();
+
+      const { content: payload } = await this.requestManager.request<GgsExtractionPayload>({
+        url: this.url,
+      });
+
+      signal?.throwIfAborted();
+
+      callback(payload);
+
+      switch (payload.state) {
+        case 'pending':
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        case 'fulfilled':
+          return;
+        case 'rejected':
+          onError(payload.error!);
+          return;
+        default:
+          throw new Error('must not happen');
+      }
+    }
+  }
+}

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -351,4 +351,128 @@ module('Acceptance | submission', function (hooks) {
 
     assert.ok(document.body.textContent?.includes('NSUB000003'), 'MASS ID is displayed');
   });
+
+  test('new submission via GGS job ID', async function (assert) {
+    const extractionFiles = [
+      {
+        name: 'test.ann',
+        basename: 'test',
+        size: 100,
+        isParsing: false,
+        parsedData: {
+          contactPerson: { fullName: 'Alice Liddell', email: 'alice@example.com', affiliation: 'Wonderland Inc.' },
+          holdDate: null,
+          entriesCount: 0,
+        },
+        isParseSucceeded: true,
+        errors: [],
+        fileType: 'annotation' as const,
+        jobId: '01234567-89ab-cdef-0000-000000000001',
+      },
+      {
+        name: 'test.fa',
+        basename: 'test',
+        size: 50,
+        isParsing: false,
+        parsedData: { entriesCount: 1 },
+        isParseSucceeded: true,
+        errors: [],
+        fileType: 'sequence' as const,
+        jobId: '01234567-89ab-cdef-0000-000000000001',
+      },
+    ];
+
+    worker.use(
+      http.get('/submissions', ({ response }) => {
+        return response(200).json({
+          submissions: [],
+        });
+      }),
+
+      http.get('/submissions/last_submitted', () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+
+      http.post('/ggs_extractions', ({ response }) => {
+        return response(201).json({
+          _self: '/ggs_extractions/1',
+          id: 1,
+          state: 'pending',
+          error: null,
+          files: [],
+        });
+      }),
+
+      http.get('/ggs_extractions/{id}', ({ response }) => {
+        return response(200).json({
+          _self: '/ggs_extractions/1',
+          id: 1,
+          state: 'fulfilled',
+          error: null,
+          files: extractionFiles,
+        });
+      }),
+
+      http.post('/submissions', ({ response }) => {
+        return response(200).json({
+          submission: { id: 'NSUB000004' },
+        });
+      }),
+    );
+
+    // --- Home page ---
+
+    await visit('/home');
+    assert.dom('h1').hasText('Home');
+
+    await click('a[href^="/home/submissions/new"]');
+
+    // --- Step 1: Prerequisite ---
+
+    assert.dom('h1').hasText('New Submission');
+
+    await clickRadio('Yes, I have determined the nucleotide sequence');
+    await click('button[type="submit"]');
+
+    // --- Step 2: Files ---
+
+    await clickRadio('Import the submission files from GGS Job ID');
+    await fillIn('textarea', '01234567-89ab-cdef-0000-000000000001');
+    await click('.card-body button[type="submit"]');
+
+    await waitUntil(() => {
+      return document.querySelectorAll('.list-group-item').length > 0;
+    });
+
+    assert.dom('.list-group-item').exists({ count: 2 });
+
+    await click('button.px-5[type="submit"]');
+
+    // --- Step 3: Metadata ---
+
+    await waitUntil(() => document.querySelector('#entriesCount'));
+
+    assert.dom('#entriesCount').hasValue('1');
+    assert.dom('#contactPerson\\.email').hasValue('alice@example.com');
+    assert.dom('#contactPerson\\.fullName').hasValue('Alice Liddell');
+    assert.dom('#contactPerson\\.affiliation').hasValue('Wonderland Inc.');
+
+    await clickRadio('NGS');
+    await fillIn('#dataType', 'wgs');
+    await clickRadio('English');
+
+    await click('button[type="submit"]');
+
+    // --- Step 4: Confirm ---
+
+    assert.dom('button[type="submit"]').hasText('Apply for registration');
+
+    await click('button[type="submit"]');
+
+    // --- Step 5: Complete ---
+
+    await waitUntil(() => document.body.textContent?.includes('NSUB000004'));
+
+    assert.ok(document.body.textContent?.includes('NSUB000004'), 'MASS ID is displayed');
+  });
 });

--- a/web/translations/en.yaml
+++ b/web/translations/en.yaml
@@ -104,6 +104,7 @@ submission-form:
       In the case where you upload the submission files, be sure to check the format and/or translation of CDS feature by <a href="https://www.ddbj.nig.ac.jp/ddbj/ume-e.html" target="_blank">UME (Parser, transChecker)</a> and fix the errors. Finally, transfer the submission files having no errors. In order to specify the hold date, you <a href="https://www.ddbj.nig.ac.jp/ddbj/file-format-e.html#date" target="_blank">need to describe the hold_date in COMMON of the annotation file</a>. You cannot specify the hold date by the input area in the form.</p>
 
     a1: Import the submission files from DFAST Job ID.
+    a4: Import the submission files from GGS Job ID.
     a2: Upload the submission files through the MSS form.
 
     a3-html: |
@@ -261,6 +262,15 @@ dfast-extractor:
     You can specify multiple job IDs by delimiting each ID with the line feed.</p>
 
   submit: Retrieve submission files from DFAST
+
+ggs-extractor:
+  ids-label: GGS job IDs
+
+  ids-help-html: |
+    <p>36-digits ID including hyphen. Specify the Job ID of a completed <a href="https://gss.ddbj.nig.ac.jp" target="_blank">GGS (Gene/genome submission tool)</a> job.<br />
+    You can specify multiple job IDs by delimiting each ID with the line feed.</p>
+
+  submit: Retrieve submission files from GGS
 
 submission.show:
   re-upload: Re-upload

--- a/web/translations/ja.yaml
+++ b/web/translations/ja.yaml
@@ -104,6 +104,7 @@ submission-form:
       登録ファイルをアップロードする場合は、事前に<a href="https://www.ddbj.nig.ac.jp/ddbj/ume.html" target="_blank">UME (Parser, transChecker)</a>にてフォーマットやCDSフィーチャーの翻訳チェックを行い、エラーのないファイルを送付してください。公開予定日を指定するには、<a href="https://www.ddbj.nig.ac.jp/ddbj/file-format.html#date" target="_blank">アノテーションファイルCOMMON領域にhold_dateの記載が必要</a>です。フォームへの入力で指定することはできません。</p>
 
     a1: DFASTのジョブIDから登録ファイルを取り込んで送付する
+    a4: GGSのジョブIDから登録ファイルを取り込んで送付する
     a2: 登録ファイルをこのMSSフォームからアップロードする
 
     a3-html: |
@@ -262,6 +263,15 @@ dfast-extractor:
     複数のjob IDを指定する場合は改行で区切ってください。</p>
 
   submit: Retrieve submission files from DFAST
+
+ggs-extractor:
+  ids-label: GGS job IDs
+
+  ids-help-html: |
+    <p>ハイフンを含めた36桁のIDです。<a href="https://gss.ddbj.nig.ac.jp" target="_blank">GGS (Gene/genome submission tool)</a> で完了したジョブのIDを指定してください。<br />
+    複数のjob IDを指定する場合は改行で区切ってください。</p>
+
+  submit: Retrieve submission files from GGS
 
 submission.show:
   re-upload: 再アップロード


### PR DESCRIPTION
## Summary

Adds a new submission-file import path that pulls DDBJ submission files (`.ann`/`.fa` pairs) generated by **GGS (Gene/genome submission tool)** into the MSS form by specifying GGS job IDs — analogous to the existing DFAST import.

Unlike DFAST (which downloads a zip over HTTP), GGS results live on the shared filesystem at `<ggs_jobs_dir_template>/<job_id>/output`, so file discovery resembles the mass-directory import: the pairs are copied straight from disk.

## Backend

- `GgsExtraction` / `GgsExtractionFile` / `GgsUpload`, `GgsExtractionsController`, routes, and jb views; `ggs` added to `Upload::VIA`.
- Discovery is restricted to `.ann`/`.fa` (GGS output is well-defined, so the lenient mass-directory extension/archive handling is not needed). Files are stored per-job under the working dir to avoid cross-job name collisions.
- Job IDs are validated as UUIDs and the resolved path is `expand_path`-guarded against traversal.
- `ggs_jobs_dir_template` added to `config/app.yml`. Production **and** staging read the GGS production volume (`/lustre9/open/home/w3dfast/ggs_volumes/jobs/{job_id}/output`); dev/test use local storage.

## Shared refactors

- New `Extraction` concern (user/files associations, `working_dir`, `normalize_path`, shared `Extraction::Error`) used by the DFAST, mass-directory, and GGS extractions.
- New `ExtractionUpload` concern for the identical `from_params` / `copy_files_to_submissions_dir` shared by the three extraction-backed uploads.
- Renamed the cross-cutting upload accessor `dfast_job_ids` → `job_ids` (JSON view, OpenAPI, and the recent-submissions table), since it is no longer DFAST-specific.

## Frontend

- `ggs-extraction` model, `ggs-extractor` component + item, a GGS radio option in the submission form, and en/ja translations.
- Drops a dead inline-error block and fixes a misspelled `spinner-border-secondary` class in both the DFAST and GGS extractor components.

## Tests

- Rails: `ggs_extractions` integration test + `GgsExtraction` model tests (pair discovery, per-job separation, duplicate-ID dedup, missing-directory rejection, UUID/blank validation).
- Ember: a "new submission via GGS job ID" acceptance test.
- All green; rubocop and the full JS/TS/Glint lint pass.

## ⚠️ Deployment note

The production config points at `/lustre9/open/home/w3dfast/ggs_volumes/...`, which is expected to already be reachable from the container. Please confirm that path is visible inside the deployed container (add a Kamal volume mount if not) before relying on this in production.