### PR TITLE
Point staging GGS imports at the test_jobs volume

### DIFF
--- a/config/app.yml
+++ b/config/app.yml
@@ -28,6 +28,7 @@ production: &production
 
 staging:
   <<: *production
-  app_url:              https://mss-staging.ddbj.nig.ac.jp
-  mail_allowed_domains: ddbj.nig.ac.jp,ursm.jp
-  web_url:              https://mss-staging.ddbj.nig.ac.jp
+  app_url:               https://mss-staging.ddbj.nig.ac.jp
+  ggs_jobs_dir_template: /lustre9/open/home/w3dfast/ggs_volumes/test_jobs/{job_id}/output
+  mail_allowed_domains:  ddbj.nig.ac.jp,ursm.jp
+  web_url:               https://mss-staging.ddbj.nig.ac.jp


### PR DESCRIPTION
## Summary

Follow-up to #1522. The GGS spec designates a separate `test_jobs/` tree for non-production use. The staging environment was inheriting the production `jobs/` path through the `<<: *production` YAML anchor; this overrides `ggs_jobs_dir_template` in the staging block so staging reads from `test_jobs/` instead.

- production: `/lustre9/open/home/w3dfast/ggs_volumes/jobs/{job_id}/output` (unchanged)
- staging: `/lustre9/open/home/w3dfast/ggs_volumes/test_jobs/{job_id}/output`

Verified both resolve correctly via `config_for(:app).ggs_jobs_dir_template!`.