### PR TITLE
Mount the GGS volume into the container

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -15,6 +15,7 @@ builder:
 
 volumes:
   - /mnt/submission:/submission
+  - /lustre9/open/home/w3dfast/ggs_volumes:/lustre9/open/home/w3dfast/ggs_volumes:ro
   - ./volumes/mssform-production/storage:/rails/storage
 
 accessories:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -19,6 +19,7 @@ env:
 
 volumes:
   - /mnt/submission:/submission
+  - /lustre9/open/home/w3dfast/ggs_volumes:/lustre9/open/home/w3dfast/ggs_volumes:ro
   - ./volumes/mssform-staging/storage:/rails/storage
 
 accessories:


### PR DESCRIPTION
## Summary

Follow-up to #1522 / #1524. GGS imports read `.ann`/`.fa` pairs from `/lustre9/open/home/w3dfast/ggs_volumes/<job_id>/output`. That tree is mounted on the Docker **hosts**, but it was never exposed to the **mssform container** — only `/mnt/submission` was. So `GgsExtraction#prepare_files` saw the directory as missing and rejected every job with `directory_not_found`.

This bind-mounts the GGS volume (read-only) at the same path inside the container for both staging and production, so the paths configured in `config/app.yml` resolve.

## Verification

Confirmed on the staging host that `/lustre9/open/home/w3dfast/ggs_volumes/test_jobs/<job_id>/output` exists and contains the expected `*.ann`/`*.fa` files; the failure was purely the missing container mount.

Read-only since the app only reads GGS outputs.