### PR TITLE
Accept the same file set as the SFTP import for GGS

### DIFF
--- a/app/models/concerns/archive_extraction.rb
+++ b/app/models/concerns/archive_extraction.rb
@@ -1,0 +1,81 @@
+module ArchiveExtraction
+  extend ActiveSupport::Concern
+
+  using Module.new {
+    refine Pathname do
+      def match_ext?(exts)
+        path = to_s
+
+        exts.find { path.end_with?(".#{_1}") }
+      end
+    end
+  }
+
+  ARCHIVE_EXT = %w[zip tar tar.gz tgz taz tar.Z taZ tar.bz2 tz2 tbz2 tbz tar.lz tar.lzma tlz tar.lzo tar.xz tar.zst tzst]
+
+  COMPRESS = {
+    gz:   %w[gzip --decompress --force],
+    Z:    %w[compress -d -f],
+    bz2:  %w[bzip2 --decompress --force],
+    lz:   %w[lzip --decompress --force],
+    lzma: %w[lzma --decompress --force],
+    lzo:  %w[lzop -d -f],
+    xz:   %w[xz --decompress --force],
+    zst:  %w[zstd -d -f]
+  }.stringify_keys
+
+  COMPRESS_EXT = ExtractionFile::FILE_EXT.product(COMPRESS.keys).map { "#{_1}.#{_2}" }
+
+  private
+
+  # Recursively scan +src_dir+ for submission files (the same set the SFTP
+  # import accepts), unarchiving and decompressing as needed, and copy each one
+  # into +dest_dir+. The block is called with the stored file name so callers
+  # can create the record with any extra attributes they need.
+  def unarchive_and_copy_files(src_dir, dest_dir, &build)
+    paths = Pathname.glob("**/*.{#{[*ExtractionFile::FILE_EXT, *ARCHIVE_EXT, *COMPRESS_EXT].join(',')}}", base: src_dir)
+
+    return if paths.empty?
+
+    dest_dir.mkpath
+
+    paths.each do |src|
+      if src.match_ext?(ExtractionFile::FILE_EXT)
+        copy_file src_dir, dest_dir, src, &build
+      elsif ext = src.match_ext?(ARCHIVE_EXT)
+        Dir.mktmpdir do |tmp|
+          tmp  = Pathname.new(tmp)
+          dest = tmp.join(src.to_s.delete_suffix(".#{ext}")).tap(&:mkpath)
+
+          if src.to_s.end_with?('.zip')
+            system 'unzip', src_dir.join(src).to_s, '-d', dest.to_s, exception: true
+          else
+            system 'tar', '--extract', '--file', src_dir.join(src).to_s, '--directory', dest.to_s, exception: true
+          end
+
+          unarchive_and_copy_files tmp, dest_dir, &build
+        end
+      elsif ext = src.match_ext?(COMPRESS_EXT)
+        comp_ext = ext.split('.').last
+
+        Dir.mktmpdir do |tmp|
+          tmp  = Pathname.new(tmp)
+          dest = tmp.join(src.dirname).tap(&:mkpath)
+
+          FileUtils.cp src_dir.join(src), dest
+          system(*COMPRESS.fetch(comp_ext), tmp.join(src).to_s, exception: true)
+
+          copy_file tmp, dest_dir, src.to_s.delete_suffix(".#{comp_ext}"), &build
+        end
+      end
+    end
+  end
+
+  def copy_file(base, dest_dir, src, &build)
+    name = normalize_path(src)
+
+    FileUtils.cp base.join(src), dest_dir.join(name)
+
+    build.call name
+  end
+end

--- a/app/models/concerns/archive_extraction.rb
+++ b/app/models/concerns/archive_extraction.rb
@@ -73,8 +73,11 @@ module ArchiveExtraction
 
   def copy_file(base, dest_dir, src, &build)
     name = normalize_path(src)
+    dest = dest_dir.join(name)
 
-    FileUtils.cp base.join(src), dest_dir.join(name)
+    raise Extraction::Error.new(:duplicate_file_name, reason: "duplicate file name: #{name}") if dest.exist?
+
+    FileUtils.cp base.join(src), dest
 
     build.call name
   end

--- a/app/models/concerns/extraction_file.rb
+++ b/app/models/concerns/extraction_file.rb
@@ -10,7 +10,7 @@ module ExtractionFile
   end
 
   ANN_EXT  = %w[ann annt.tsv ann.txt]
-  SEQ_EXT  = %w[fasta seq.fa fa fna seq]
+  SEQ_EXT  = %w[fasta fsa seq.fa fa fna seq]
   FILE_EXT = ANN_EXT + SEQ_EXT
 
   def fullpath = extraction.working_dir.join(name)

--- a/app/models/ggs_extraction.rb
+++ b/app/models/ggs_extraction.rb
@@ -1,7 +1,6 @@
 class GgsExtraction < ApplicationRecord
   include Extraction
-
-  EXTENSIONS = %w[ann fa].freeze
+  include ArchiveExtraction
 
   UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
 
@@ -14,34 +13,22 @@ class GgsExtraction < ApplicationRecord
   end
 
   def prepare_files
-    working_dir.mkpath
-
     ActiveRecord::Base.transaction do
       ggs_job_ids.uniq.each do |job_id|
-        copy_files job_id
+        copy_job_files job_id
       end
     end
   end
 
   private
 
-  def copy_files(job_id)
+  def copy_job_files(job_id)
     src_dir = job_output_dir(job_id)
 
     raise Extraction::Error.new(:directory_not_found, job_id:) unless src_dir.directory?
 
-    dest_dir = working_dir.join(job_id).tap(&:mkpath)
-
-    Pathname.glob("*.{#{EXTENSIONS.join(',')}}", base: src_dir).each do |rel|
-      name = normalize_path(rel)
-
-      FileUtils.cp src_dir.join(rel), dest_dir.join(name)
-
-      files.create!(
-        name:,
-        parsing:    true,
-        ggs_job_id: job_id
-      )
+    unarchive_and_copy_files(src_dir, working_dir.join(job_id)) do |name|
+      files.create!(name:, parsing: true, ggs_job_id: job_id)
     end
   end
 

--- a/app/models/mass_directory_extraction.rb
+++ b/app/models/mass_directory_extraction.rb
@@ -1,34 +1,12 @@
-using Module.new {
-  refine Pathname do
-    def match_ext?(exts)
-      path = to_s
-
-      exts.find { path.end_with?(".#{_1}") }
-    end
-  end
-}
-
 class MassDirectoryExtraction < ApplicationRecord
   include Extraction
-
-  ARCHIVE_EXT = %w[zip tar tar.gz tgz taz tar.Z taZ tar.bz2 tz2 tbz2 tbz tar.lz tar.lzma tlz tar.lzo tar.xz tar.zst tzst]
-
-  COMPRESS = {
-    gz:   %w[gzip --decompress --force],
-    Z:    %w[compress -d -f],
-    bz2:  %w[bzip2 --decompress --force],
-    lz:   %w[lzip --decompress --force],
-    lzma: %w[lzma --decompress --force],
-    lzo:  %w[lzop -d -f],
-    xz:   %w[xz --decompress --force],
-    zst:  %w[zstd -d -f]
-  }.stringify_keys
-
-  COMPRESS_EXT = ExtractionFile::FILE_EXT.product(COMPRESS.keys).map { "#{_1}.#{_2}" }
+  include ArchiveExtraction
 
   def prepare_files
     ActiveRecord::Base.transaction do
-      unarchive_and_copy_files user_mass_dir
+      unarchive_and_copy_files(user_mass_dir, working_dir) do |name|
+        files.create!(name:, parsing: true)
+      end
     end
   end
 
@@ -38,55 +16,5 @@ class MassDirectoryExtraction < ApplicationRecord
     Rails.application.config_for(:app).mass_dir_path_template!.gsub('{user}', user.uid).tap {|path|
       raise "malformed directory path: #{path}" unless path == File.expand_path(path)
     }.then { Pathname.new(_1) }
-  end
-
-  def unarchive_and_copy_files(dir)
-    paths = Pathname.glob("**/*.{#{[*ExtractionFile::FILE_EXT, *ARCHIVE_EXT, *COMPRESS_EXT].join(',')}}", base: dir)
-
-    return if paths.empty?
-
-    working_dir.mkpath
-
-    paths.each do |src|
-      if src.match_ext?(ExtractionFile::FILE_EXT)
-        copy_file dir, src
-      elsif ext = src.match_ext?(ARCHIVE_EXT)
-        Dir.mktmpdir do |tmp|
-          tmp  = Pathname.new(tmp)
-          dest = tmp.join(src.to_s.delete_suffix(".#{ext}")).tap(&:mkpath)
-
-          if src.to_s.end_with?('.zip')
-            system 'unzip', dir.join(src).to_s, '-d', dest.to_s, exception: true
-          else
-            system 'tar', '--extract', '--file', dir.join(src).to_s, '--directory', dest.to_s, exception: true
-          end
-
-          unarchive_and_copy_files tmp
-        end
-      elsif ext = src.match_ext?(COMPRESS_EXT)
-        comp_ext = ext.split('.').last
-
-        Dir.mktmpdir do |tmp|
-          tmp  = Pathname.new(tmp)
-          dest = tmp.join(src.dirname).tap(&:mkpath)
-
-          FileUtils.cp dir.join(src), dest
-          system(*COMPRESS.fetch(comp_ext), tmp.join(src).to_s, exception: true)
-
-          copy_file tmp, src.to_s.delete_suffix(".#{comp_ext}")
-        end
-      end
-    end
-  end
-
-  def copy_file(base, src)
-    dest = normalize_path(src)
-
-    FileUtils.cp base.join(src), working_dir.join(dest)
-
-    files.create!(
-      name:    dest,
-      parsing: true
-    )
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,17 +3,17 @@
     {
       "warning_type": "Command Injection",
       "warning_code": 14,
-      "fingerprint": "15fa85042e7af236350f1d3c02c863486c9ff3dba075e4da02b46da78c814cae",
+      "fingerprint": "95f4ed11644898064fa295c67cd8d3baa1f2b85a8e305b0fa1ae6478fb08c9cc",
       "check_name": "Execute",
       "message": "Possible command injection",
-      "file": "app/models/mass_directory_extraction.rb",
-      "line": 82,
+      "file": "app/models/concerns/archive_extraction.rb",
+      "line": 66,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "system(*{ :gz => ([\"gzip\", \"--decompress\", \"--force\"]), :Z => ([\"compress\", \"-d\", \"-f\"]), :bz2 => ([\"bzip2\", \"--decompress\", \"--force\"]), :lz => ([\"lzip\", \"--decompress\", \"--force\"]), :lzma => ([\"lzma\", \"--decompress\", \"--force\"]), :lzo => ([\"lzop\", \"-d\", \"-f\"]), :xz => ([\"xz\", \"--decompress\", \"--force\"]), :zst => ([\"zstd\", \"-d\", \"-f\"]) }.stringify_keys.fetch(src.match_ext?(ExtractionFile::FILE_EXT.product({ :gz => ([\"gzip\", \"--decompress\", \"--force\"]), :Z => ([\"compress\", \"-d\", \"-f\"]), :bz2 => ([\"bzip2\", \"--decompress\", \"--force\"]), :lz => ([\"lzip\", \"--decompress\", \"--force\"]), :lzma => ([\"lzma\", \"--decompress\", \"--force\"]), :lzo => ([\"lzop\", \"-d\", \"-f\"]), :xz => ([\"xz\", \"--decompress\", \"--force\"]), :zst => ([\"zstd\", \"-d\", \"-f\"]) }.stringify_keys.keys).map do\n \"#{_1}.#{_2}\"\n end).split(\".\").last), Pathname.new(tmp).join(src).to_s, :exception => true)",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "MassDirectoryExtraction",
+        "class": "ArchiveExtraction",
         "method": "unarchive_and_copy_files"
       },
       "user_input": "_1",
@@ -21,9 +21,9 @@
       "cwe_id": [
         77
       ],
-      "note": ""
+      "note": "Decompression commands come from the hardcoded COMPRESS constant, not user input."
     }
   ],
-  "updated": "2024-08-15 00:06:52 +0900",
-  "brakeman_version": "6.1.2"
+  "updated": "2026-06-28 17:00:00 +0900",
+  "brakeman_version": "8.0.5"
 }

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -31,6 +31,23 @@ class GgsExtractionTest < ActiveSupport::TestCase
     assert files.all? { _1.fullpath.exist? }
   end
 
+  test 'prepare_files accepts the same file set as the SFTP import (fasta, annt.tsv, gz)' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+
+    dir.join('a.fasta').write    ">CLN01\nACGT\n"
+    dir.join('b.annt.tsv').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+
+    Zlib::GzipWriter.open(dir.join('c.fa.gz')) do |gz|
+      gz.write ">CLN02\nACGT\n"
+    end
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+    extraction.prepare_files
+
+    assert_equal %w[a.fasta b.annt.tsv c.fa], extraction.files.order(:name).map(&:name)
+  end
+
   test 'prepare_files keeps files from different jobs separate' do
     job1 = '01234567-89ab-cdef-0000-000000000001'
     job2 = '01234567-89ab-cdef-0000-000000000002'

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -31,21 +31,38 @@ class GgsExtractionTest < ActiveSupport::TestCase
     assert files.all? { _1.fullpath.exist? }
   end
 
-  test 'prepare_files accepts the same file set as the SFTP import (fasta, annt.tsv, gz)' do
+  test 'prepare_files accepts the same file set as the SFTP import (fasta, fsa, annt.tsv, gz)' do
     job_id = '01234567-89ab-cdef-0000-000000000001'
     dir    = output_dir(job_id)
 
     dir.join('a.fasta').write    ">CLN01\nACGT\n"
     dir.join('b.annt.tsv').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    dir.join('c.fsa').write      ">CLN02\nACGT\n"
 
-    Zlib::GzipWriter.open(dir.join('c.fa.gz')) do |gz|
-      gz.write ">CLN02\nACGT\n"
+    Zlib::GzipWriter.open(dir.join('d.fa.gz')) do |gz|
+      gz.write ">CLN03\nACGT\n"
     end
 
     extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
     extraction.prepare_files
 
-    assert_equal %w[a.fasta b.annt.tsv c.fa], extraction.files.order(:name).map(&:name)
+    assert_equal %w[a.fasta b.annt.tsv c.fsa d.fa], extraction.files.order(:name).map(&:name)
+  end
+
+  test 'prepare_files rejects files whose names collide after normalization' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+
+    dir.join('a b.fa').write ">CLN01\nACGT\n"
+    dir.join('a_b.fa').write ">CLN02\nACGT\n"
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+
+    error = assert_raises Extraction::Error do
+      extraction.prepare_files
+    end
+
+    assert_equal :duplicate_file_name, error.id
   end
 
   test 'prepare_files keeps files from different jobs separate' do

--- a/web/app/models/submission-file.ts
+++ b/web/app/models/submission-file.ts
@@ -163,7 +163,7 @@ export class AnnotationFile extends SubmissionFile {
 }
 
 export class SequenceFile extends SubmissionFile {
-  static extensions = ['.fasta', '.seq.fa', '.fa', '.fna', '.seq'];
+  static extensions = ['.fasta', '.fsa', '.seq.fa', '.fa', '.fna', '.seq'];
   static parserURL = '/workers/sequence-file-parser.js';
 
   fileType = 'sequence' as const;


### PR DESCRIPTION
## Summary

The GGS spec (Confluence 3108339825) says the imported file extensions must be **the same as the SFTP import** — but #1522 only globbed top-level `*.ann`/`*.fa`. (That narrowing was a misread of the spec on our side.)

This extracts the mass-directory directory walk into a shared **`ArchiveExtraction`** concern and uses it from both `MassDirectoryExtraction` and `GgsExtraction`, so GGS now accepts exactly what the SFTP import does:

- `ExtractionFile::FILE_EXT` — `ann`, `annt.tsv`, `ann.txt`, `fasta`, `fsa`, `seq.fa`, `fa`, `fna`, `seq`
- archives (`zip`/`tar` family) — unpacked recursively
- compression (`gz`, `bz2`, `xz`, …) — decompressed

The per-source differences are passed in: the source dir, the destination dir (mass → `working_dir`; GGS → `working_dir/<job_id>`), and a block that builds each file record (GGS attaches `ggs_job_id`).

**Mass-directory behavior is unchanged** for the happy path (same code path, just parameterized).

## Also in this PR (from review)

- **`.fsa`** added to the sequence extension set, matching the spec's example. Applied to both the backend (`SEQ_EXT`) and the frontend (`SequenceFile.extensions`, which also drives the "supported file types" display), so the webui upload and the import flows stay consistent.
- **Duplicate file names are now rejected.** Because the import recurses/unarchives, two source files can normalize to the same stored name. The shared copy step now raises a clear `Extraction::Error` (`duplicate_file_name`) when a destination already exists, instead of letting it surface as an unrescued `RecordNotUnique` that left the extraction stuck `pending`. This hardens both the mass-directory and GGS imports.

## Tests

- `GgsExtraction`: expanded-set test (`.fasta`, `.fsa`, `.annt.tsv`, gz-compressed `.fa.gz`) and a duplicate-name rejection test.
- Full Rails suite (43) + Ember suite (25) pass; rubocop and Glint/JS/CSS/HBS lint clean.