### PR TITLE
Require agreement to the Terms of Use before proceeding

### DIFF
--- a/web/app/components/submission-form.gts
+++ b/web/app/components/submission-form.gts
@@ -85,6 +85,7 @@ export default class SubmissionFormComponent extends Component<Signature> {
 
 export class State {
   @tracked maybeTpa: boolean | null = null;
+  @tracked agreed = false;
   @tracked files: SubmissionFileData[] = [];
 }
 

--- a/web/app/components/submission-form/prerequisite.gts
+++ b/web/app/components/submission-form/prerequisite.gts
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
-import { eq, and } from 'ember-truth-helpers';
+import { eq, and, not } from 'ember-truth-helpers';
 import svgJar from 'ember-svg-jar/helpers/svg-jar';
 
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
@@ -29,6 +29,10 @@ export default class SubmissionFormPrerequisiteComponent extends Component<Signa
 
   @action setTpa(value: boolean) {
     this.args.model.tpa = value;
+  }
+
+  @action setAgreed(event: Event) {
+    this.args.state.agreed = (event.target as HTMLInputElement).checked;
   }
 
   @action handleSubmit(event: Event) {
@@ -136,8 +140,24 @@ export default class SubmissionFormPrerequisiteComponent extends Component<Signa
 
         <LinkTo @route="home">{{t "go-to-home"}}</LinkTo>
       {{else}}
-        <div class="hstack gap-3 justify-content-end">
-          <button type="submit" class="btn btn-primary px-5">{{t "submission-form.nav.next"}}</button>
+        <div class="hstack gap-3">
+          <div class="form-check me-auto">
+            <input
+              id="agree-terms"
+              type="checkbox"
+              checked={{@state.agreed}}
+              class="form-check-input"
+              {{on "change" this.setAgreed}}
+            />
+
+            <label for="agree-terms" class="form-check-label">
+              {{t "submission-form.prerequisite.agree-html" htmlSafe=true}}
+            </label>
+          </div>
+
+          <button type="submit" disabled={{not @state.agreed}} class="btn btn-primary px-5">
+            {{t "submission-form.nav.next"}}
+          </button>
         </div>
       {{/if}}
     </form>

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -55,6 +55,13 @@ module('Acceptance | submission', function (hooks) {
     assert.dom('h1').hasText('New Submission');
 
     await clickRadio('Yes, I have determined the nucleotide sequence');
+
+    assert.dom('button.px-5[type="submit"]').isDisabled('Next is disabled until the terms are agreed to');
+
+    await click('#agree-terms');
+
+    assert.dom('button.px-5[type="submit"]').isNotDisabled('Next is enabled once the terms are agreed to');
+
     await click('button[type="submit"]');
 
     // --- Step 2: Files ---
@@ -188,6 +195,7 @@ module('Acceptance | submission', function (hooks) {
     assert.dom('h1').hasText('New Submission');
 
     await clickRadio('Yes, I have determined the nucleotide sequence');
+    await click('#agree-terms');
     await click('button[type="submit"]');
 
     // --- Step 2: Files ---
@@ -310,6 +318,7 @@ module('Acceptance | submission', function (hooks) {
     assert.dom('h1').hasText('New Submission');
 
     await clickRadio('Yes, I have determined the nucleotide sequence');
+    await click('#agree-terms');
     await click('button[type="submit"]');
 
     // --- Step 2: Files ---
@@ -432,6 +441,7 @@ module('Acceptance | submission', function (hooks) {
     assert.dom('h1').hasText('New Submission');
 
     await clickRadio('Yes, I have determined the nucleotide sequence');
+    await click('#agree-terms');
     await click('button[type="submit"]');
 
     // --- Step 2: Files ---

--- a/web/translations/en.yaml
+++ b/web/translations/en.yaml
@@ -98,6 +98,9 @@ submission-form:
 
     unacceptable: Regarding TPA, you cannot apply to MSS unless you will prepare a paper.
 
+    agree-html: |
+      I have read and agree to the <a href="https://www.ddbj.nig.ac.jp/policies-e.html" target="_blank">Terms of Use</a>.
+
   files:
     q-html: |
       <p>Select the file transferring method for the submission.<br />

--- a/web/translations/ja.yaml
+++ b/web/translations/ja.yaml
@@ -98,6 +98,9 @@ submission-form:
 
     unacceptable: TPA の場合、論文を準備しないのであれば申し込みできません。
 
+    agree-html: |
+      <a href="https://www.ddbj.nig.ac.jp/policies.html" target="_blank">利用規約</a>に同意します。
+
   files:
     q-html: |
       <p>Submission ファイルの送付方法を選択してください。<br />


### PR DESCRIPTION
## Summary

Adds a Terms of Use consent checkbox to the first step (Requirement) of the MSS submission form. The **Next** button is disabled until the user ticks it.

This is the MSS-form part of the epic to surface the Terms of Use across all registration forms, driven by the ABS/BBNJ requirement for registrants to acknowledge the terms (DB-2068 / DB-2070).

## Behavior

- Checkbox sits to the left of the **Next** button on the Requirement step.
- Label links to the Terms of Use — `policies.html` (JA) / `policies-e.html` (EN).
- Agreement is held in the shared form `State`, so it survives navigating back and forth between steps; a fresh submission starts unchecked.
- In the TPA-unacceptable branch (where Next is replaced by a "go home" link) no checkbox is shown, since there is nothing to gate.

## Testing

- `pnpm lint` — types / hbs / js / css / format all pass
- `pnpm test:ember` — 25 tests pass, including a new assertion that Next is disabled until the terms are agreed to, plus the consent step wired into all four submission flows (webui / DFAST / mass directory / GGS)

Refs DB-2070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)