### PR TITLE
Serve the SPA shell through the controller so runtime config is always injected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,10 @@ COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /rails /rails
 COPY --from=web /web/dist/ /rails/public
 
+# FrontendsController serves the SPA shell with the runtime config injected, so it
+# must not be served statically from public/. Move it out of the way.
+RUN mv public/index.html app/views/frontends/show.html
+
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid ${APP_GID:?} rails && \
     useradd rails --uid ${APP_UID:?} --gid ${APP_GID:?} --create-home --shell /bin/bash && \

--- a/app/controllers/frontends_controller.rb
+++ b/app/controllers/frontends_controller.rb
@@ -1,14 +1,19 @@
 class FrontendsController < ActionController::Base
-  # Serve the pre-built SPA shell, injecting the runtime configuration that must
-  # not be baked into the environment-agnostic build (so a single image can be
-  # promoted across environments). The frontend reads these <meta> tags on boot.
+  # Serve the SPA shell, injecting the runtime configuration that must not be baked
+  # into the environment-agnostic build (so a single image can be promoted across
+  # environments). The frontend reads these <meta> tags on boot.
+  #
+  # The shell deliberately lives outside public/ so the static file server never
+  # serves it directly, which would bypass this injection. Every document request is
+  # routed here instead (see config/routes.rb); the Dockerfile moves the built shell
+  # into place.
   def show
-    html = Rails.root.join('public/index.html').read
+    html = Rails.root.join('app/views/frontends/show.html').read
     meta = helpers.safe_join([
       helpers.tag.meta(name: 'sentry-dsn',         content: Rails.application.config_for(:app).sentry_dsn),
       helpers.tag.meta(name: 'sentry-environment', content: Rails.env)
     ])
 
-    render html: html.sub('</head>', "#{meta}</head>").html_safe
+    render html: html.sub('</head>') { "#{meta}</head>" }.html_safe
   end
 end

--- a/app/views/frontends/show.html
+++ b/app/views/frontends/show.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>MSS Application Form</title>
+  </head>
+
+  <body>
+    <!--
+      In production this file is replaced by the SPA shell built from web/ (see the
+      Dockerfile). It is kept in the repository so the backend can boot and serve a
+      valid document in development and test, where the frontend is otherwise served
+      by the Vite dev server.
+    -->
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: redirect('/web')
+  root to: 'frontends#show'
 
   get 'auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure',            to: 'sessions#failure'

--- a/test/integration/frontends_test.rb
+++ b/test/integration/frontends_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class FrontendsTest < ActionDispatch::IntegrationTest
+  test 'root serves the SPA shell with the runtime config injected' do
+    get '/'
+
+    assert_response :success
+    assert_select 'meta[name=?]', 'sentry-dsn'
+    assert_select 'meta[name=?][content=?]', 'sentry-environment', 'test'
+  end
+
+  test 'client-side routes serve the SPA shell too' do
+    get '/home/submission/new'
+
+    assert_response :success
+    assert_select 'meta[name=?][content=?]', 'sentry-environment', 'test'
+  end
+
+  test 'injects the configured Sentry DSN into the shell' do
+    config = ActiveSupport::OrderedOptions.new
+    config.sentry_dsn = 'https://public@sentry.example.com/1'
+
+    Rails.application.stub :config_for, ->(*) { config } do
+      get '/'
+    end
+
+    assert_select 'meta[name=?][content=?]', 'sentry-dsn', 'https://public@sentry.example.com/1'
+  end
+end


### PR DESCRIPTION
## Problem

The environment-agnostic build (#1535) injects the Sentry DSN and environment as `<meta>` tags at request time via `FrontendsController`, keeping the built image promotable across environments (`kamal deploy -P`).

However, the built shell is copied into `public/`, so `ActionDispatch::Static` (and Thruster, in the container) serves it **directly**:

| Request | Before |
|---|---|
| `GET /` | **STATIC** `public/index.html` — no injection ❌ |
| `GET /index.html` | **STATIC** — no injection ❌ |
| `GET /home/...` (deep link) | controller — injected ✅ |

Since `/` is the app's canonical entry (rootURL is `/`), the Sentry config was silently dropped for most first loads. Verified with `ActionDispatch::Static` in the production config.

## Fix

Move the shell out of the statically-served tree so **every** document request is routed through `FrontendsController`:

- The Dockerfile relocates the built `index.html` to `app/views/frontends/show.html` after copying `web/dist/` into `public/`.
- A committed placeholder at that path keeps the backend bootable in development/test (where the Vite dev server serves the frontend); the image overwrites it with the real shell.
- `root` now points at `frontends#show`. The old `redirect('/web')` was dead code — the static server answered `/` before the router, and even if it fired, rootURL is `/` so `/web` falls through to the SPA's not-found route.

After the fix, `/`, `/index.html`, and every deep link all reach the controller; only real files (`/assets/*`, `/@embroider/*`, `favicon.ico`, `robots.txt`) are served statically.

## Also

- Use the block form of `String#sub` to avoid backreference interpretation (`\1`, `\&`, `\\`) in the injected markup.
- Add an integration test covering injection at `/`, at a deep link, and of the configured DSN value.

## Test

`bin/rails test` → 46 runs, 0 failures. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)