### PR TITLE
Require agreement to the Terms of Use at the confirmation step

### DIFF
--- a/web/app/components/submission-form.gts
+++ b/web/app/components/submission-form.gts
@@ -86,6 +86,7 @@ export default class SubmissionFormComponent extends Component<Signature> {
 
 export class State {
   @tracked maybeTpa: boolean | null = null;
+  @tracked agreed = false;
   @tracked files: SubmissionFileData[] = [];
 }
 

--- a/web/app/components/submission-form/confirm.gts
+++ b/web/app/components/submission-form/confirm.gts
@@ -31,6 +31,10 @@ export interface Signature {
 export default class SubmissionFormConfirmComponent extends Component<Signature> {
   @service declare requestManager: RequestManager;
 
+  @action setAgreed(event: Event) {
+    this.args.state.agreed = (event.target as HTMLInputElement).checked;
+  }
+
   @action async submit(uploadProgressModal: UploadProgressModalComponent, event: Event) {
     event.preventDefault();
     const { state, model, nav } = this.args;
@@ -209,6 +213,26 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
             </div>
           </div>
 
+          <div class="card">
+            <div class="card-body">
+              <div class="form-check mb-3">
+                <input
+                  id="agree-terms"
+                  type="checkbox"
+                  checked={{@state.agreed}}
+                  class="form-check-input"
+                  {{on "change" this.setAgreed}}
+                />
+
+                <label for="agree-terms" class="form-check-label">
+                  {{t "submission-form.confirm.agree"}}
+                </label>
+              </div>
+
+              {{t "submission-form.confirm.read-more-html" htmlSafe=true}}
+            </div>
+          </div>
+
           <p>{{t "submission-form.confirm.confirm-message"}}</p>
         </div>
 
@@ -218,7 +242,9 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
           <button type="button" class="btn btn-outline-primary px-4" {{on "click" @nav.goPrev}}>{{t
               "submission-form.nav.back"
             }}</button>
-          <button type="submit" class="btn btn-primary px-5">{{t "submission-form.confirm.submit"}}</button>
+          <button type="submit" disabled={{not @state.agreed}} class="btn btn-primary px-5">{{t
+              "submission-form.confirm.submit"
+            }}</button>
         </div>
       </form>
     </UploadProgressModal>

--- a/web/app/components/submission-form/prerequisite.gts
+++ b/web/app/components/submission-form/prerequisite.gts
@@ -138,7 +138,9 @@ export default class SubmissionFormPrerequisiteComponent extends Component<Signa
       <hr />
 
       <div class="hstack gap-3 justify-content-end">
-        <button type="submit" class="btn btn-primary px-5">{{t "submission-form.nav.next"}}</button>
+        <button type="submit" disabled={{not (or (eq @state.maybeTpa false) @model.tpa)}} class="btn btn-primary px-5">
+          {{t "submission-form.nav.next"}}
+        </button>
       </div>
     </form>
   </template>

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -100,6 +100,12 @@ module('Acceptance | submission', function (hooks) {
 
     assert.dom('button[type="submit"]').hasText('Apply for registration');
 
+    assert.dom('button.px-5[type="submit"]').isDisabled('Submit is disabled until the terms are agreed to');
+
+    await click('#agree-terms');
+
+    assert.dom('button.px-5[type="submit"]').isNotDisabled('Submit is enabled once the terms are agreed to');
+
     await click('button[type="submit"]');
 
     // --- Step 5: Complete ---
@@ -107,6 +113,31 @@ module('Acceptance | submission', function (hooks) {
     await waitUntil(() => document.body.textContent?.includes('NSUB000001'));
 
     assert.ok(document.body.textContent?.includes('NSUB000001'), 'MASS ID is displayed');
+  });
+
+  test('the unacceptable TPA answer cannot proceed past the prerequisite step', async function (assert) {
+    worker.use(
+      http.get('/submissions', ({ response }) => {
+        return response(200).json({
+          submissions: [],
+        });
+      }),
+
+      http.get('/submissions/last_submitted', () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+    );
+
+    await visit('/home');
+    await click('a[href^="/home/submissions/new"]');
+
+    // --- Step 1: Prerequisite ---
+
+    await clickRadio('No, I have created the nucleotide sequences by assembling from the publicly available data.');
+    await clickRadio('No, I have no plan to submit a paper.');
+
+    assert.dom('form').containsText('you cannot apply to MSS unless you will prepare a paper');
+    assert.dom('button.px-5[type="submit"]').isDisabled('Next stays disabled for the unacceptable TPA answer');
   });
 
   test('new submission via DFAST job ID', async function (assert) {
@@ -224,6 +255,7 @@ module('Acceptance | submission', function (hooks) {
 
     assert.dom('button[type="submit"]').hasText('Apply for registration');
 
+    await click('#agree-terms');
     await click('button[type="submit"]');
 
     // --- Step 5: Complete ---
@@ -344,6 +376,7 @@ module('Acceptance | submission', function (hooks) {
 
     assert.dom('button[type="submit"]').hasText('Apply for registration');
 
+    await click('#agree-terms');
     await click('button[type="submit"]');
 
     // --- Step 5: Complete ---
@@ -468,6 +501,7 @@ module('Acceptance | submission', function (hooks) {
 
     assert.dom('button[type="submit"]').hasText('Apply for registration');
 
+    await click('#agree-terms');
     await click('button[type="submit"]');
 
     // --- Step 5: Complete ---

--- a/web/translations/en.yaml
+++ b/web/translations/en.yaml
@@ -189,6 +189,17 @@ submission-form:
 
     blank: Blank
     confirm-message: Please, check the information, then press the "Apply for registration" button. You cannot modify the information after clicking.
+
+    agree: I confirm that, to the best of my knowledge, the data submitted here are not subject to any restrictions that would prevent their open sharing through the databases operated by the BioData Science Initiative (BSI). I have also reviewed and agreed to the BSI Terms of Use, including the provisions on the rights and duties of submitters, the handling of human-derived research data, and the access and benefit-sharing (ABS) of genetic resources.
+
+    read-more-html: |
+      <p>Read more:</p>
+
+      <ul class="mb-0">
+        <li><a href="https://www.ddbj.nig.ac.jp/policies-e.html" target="_blank">BSI Terms of Use</a></li>
+        <li><a href="https://www.ddbj.nig.ac.jp/faq/en/abs-data-sharing-e.html" target="_blank">Applicable national and international laws and rules on access and benefit-sharing</a></li>
+      </ul>
+
     submit: Apply for registration
 
   complete:

--- a/web/translations/ja.yaml
+++ b/web/translations/ja.yaml
@@ -190,6 +190,17 @@ submission-form:
 
     blank: なし
     confirm-message: 入力内容をご確認のうえ、よろしければ登録申請ボタンを押してください。クリック後は修正できません。
+
+    agree: 私は、ここで登録するデータが、私の知る限り、バイオデータ研究拠点（BSI）が運用するデータベースを通じて制限なく公開・共有できることを承認します。また、登録者の権利と義務、ヒト由来研究データの取り扱い、ならびに遺伝資源のアクセスと利益配分（ABS）に関する規定を含むBSI利用規約を確認し、これに同意します。
+
+    read-more-html: |
+      <p>詳しくはこちら:</p>
+
+      <ul class="mb-0">
+        <li><a href="https://www.ddbj.nig.ac.jp/policies.html" target="_blank">BSI利用規約</a></li>
+        <li><a href="https://www.ddbj.nig.ac.jp/faq/ja/abs-data-sharing.html" target="_blank">アクセスと利益配分に関する国内外の法令・ルール</a></li>
+      </ul>
+
     submit: 登録申請
 
   complete:


### PR DESCRIPTION
## What

Adds the consent to the BSI Terms of Use on the final wizard step (Confirmation of the application), gating the "Apply for registration" button. This is the **complete, self-contained Terms of Use feature**.

It is intentionally kept **off `main`** so its release can be coordinated to go live at the same time across the DDBJ services. Merge this when that coordinated release happens.

## Relationship to main

The earlier prerequisite-step version of the consent was removed from `main` in `0572d529` ("Remove the Terms of Use consent to coordinate its release"), so this branch sits directly on top of that and re-introduces the feature in its final form. Net effect once merged: consent collected at the confirmation step.

## Details

- Consent checkbox + "Read more" links live in `submission-form/confirm.gts`; `agree` / `read-more-html` translations under the `confirm` block.
- The requirement step's Next button is gated on the answer itself (`disabled={{not (or (eq @state.maybeTpa false) @model.tpa)}}`), so the unacceptable "TPA but no paper" dead end still cannot advance — previously the (now-moved) consent checkbox doubled as that gate. Covered by a new acceptance test.

## Test

`pnpm test:ember` → 26 pass (4 wizard flows agree at the confirm step; a new test asserts the unacceptable TPA answer stays blocked). `bin/rails test` → 46 pass. Lint (incl. Glint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)