### PR TITLE
Prefer output/fixed/ files over output/ in GGS imports

### DIFF
--- a/app/models/ggs_extraction.rb
+++ b/app/models/ggs_extraction.rb
@@ -27,8 +27,31 @@ class GgsExtraction < ApplicationRecord
 
     raise Extraction::Error.new(:directory_not_found, job_id:) unless src_dir.directory?
 
-    unarchive_and_copy_files(src_dir, working_dir.join(job_id)) do |name|
-      files.create!(name:, parsing: true, ggs_job_id: job_id)
+    # Corrected files live under output/fixed/ and take priority over the same-named
+    # files in output/. Pick a single source per file name (fixed winning, unmatched
+    # output/ files kept), copy them into a flat directory, and import that so each
+    # file is stored once under its own basename. Resolving before copying keeps a
+    # read-only output/ file from being overwritten in place (which would fail).
+    sources = {}
+
+    [src_dir, src_dir.join('fixed')].each do |dir|
+      next unless dir.directory?
+
+      dir.each_child do |child|
+        sources[child.basename.to_s] = child if child.file?
+      end
+    end
+
+    Dir.mktmpdir do |tmp|
+      merged = Pathname.new(tmp)
+
+      sources.each_value do |src|
+        FileUtils.cp src, merged
+      end
+
+      unarchive_and_copy_files(merged, working_dir.join(job_id)) do |name|
+        files.create!(name:, parsing: true, ggs_job_id: job_id)
+      end
     end
   end
 

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -31,6 +31,84 @@ class GgsExtractionTest < ActiveSupport::TestCase
     assert files.all? { _1.fullpath.exist? }
   end
 
+  test 'prepare_files prefers output/fixed/ over output/ for the same file name' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+    fixed  = dir.join('fixed').tap(&:mkpath)
+
+    dir.join('foo.ann').write   "COMMON\tSUBMITTER\t\tcontact\tOutput\n"
+    dir.join('foo.fa').write    ">output\nACGT\n"
+    fixed.join('foo.ann').write "COMMON\tSUBMITTER\t\tcontact\tFixed\n"
+    fixed.join('foo.fa').write  ">fixed\nACGT\n"
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+    extraction.prepare_files
+
+    files = extraction.files.order(:name)
+
+    assert_equal %w[foo.ann foo.fa], files.map(&:name)
+    assert_equal "COMMON\tSUBMITTER\t\tcontact\tFixed\n", files.first.fullpath.read
+    assert_equal ">fixed\nACGT\n",                        files.last.fullpath.read
+  end
+
+  test 'prepare_files prefers output/fixed/ even when the output/ files are read-only' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+    fixed  = dir.join('fixed').tap(&:mkpath)
+
+    dir.join('foo.ann').write   "COMMON\tSUBMITTER\t\tcontact\tOutput\n"
+    dir.join('foo.fa').write    ">output\nACGT\n"
+    fixed.join('foo.ann').write "COMMON\tSUBMITTER\t\tcontact\tFixed\n"
+    fixed.join('foo.fa').write  ">fixed\nACGT\n"
+
+    # GGS job output lives on a shared filesystem and may be read-only.
+    [dir, fixed].each {|d| d.each_child { _1.chmod(0o444) if _1.file? } }
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+    extraction.prepare_files
+
+    files = extraction.files.order(:name)
+
+    assert_equal %w[foo.ann foo.fa], files.map(&:name)
+    assert_equal ">fixed\nACGT\n", files.last.fullpath.read
+  end
+
+  test 'prepare_files keeps output/ files that have no counterpart under output/fixed/' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+    fixed  = dir.join('fixed').tap(&:mkpath)
+
+    dir.join('a.ann').write   "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    dir.join('a.fa').write    ">output\nACGT\n"
+    dir.join('b.ann').write   "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    dir.join('b.fa').write    ">b\nACGT\n"
+    fixed.join('a.fa').write  ">fixed\nACGT\n"
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+    extraction.prepare_files
+
+    files = extraction.files.order(:name)
+
+    assert_equal %w[a.ann a.fa b.ann b.fa], files.map(&:name)
+    assert_equal ">fixed\nACGT\n", files.find { _1.name == 'a.fa' }.fullpath.read
+    assert_equal ">b\nACGT\n",     files.find { _1.name == 'b.fa' }.fullpath.read
+  end
+
+  test 'prepare_files ignores subdirectories other than fixed (e.g. reports)' do
+    job_id  = '01234567-89ab-cdef-0000-000000000001'
+    dir     = output_dir(job_id)
+    reports = dir.join('reports').tap(&:mkpath)
+
+    dir.join('foo.ann').write     "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    dir.join('foo.fa').write      ">foo\nACGT\n"
+    reports.join('report.fa').write ">report\nACGT\n"
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+    extraction.prepare_files
+
+    assert_equal %w[foo.ann foo.fa], extraction.files.order(:name).map(&:name)
+  end
+
   test 'prepare_files accepts the same file set as the SFTP import (fasta, fsa, annt.tsv, gz)' do
     job_id = '01234567-89ab-cdef-0000-000000000001'
     dir    = output_dir(job_id)


### PR DESCRIPTION
## Problem

A GGS job writes corrected files into an `output/fixed/` subdirectory alongside the originals in `output/`. The import scanned the output directory recursively, so a file that had a corrected version was fetched **twice** — once as `foo.ann` (from `output/`) and once as `fixed__foo.ann` (from `output/fixed/`).

## Change

Resolve a single source per file name — `output/fixed/` wins, unmatched `output/` files are kept — copy the chosen files into a flat directory, and import that. Each file is now stored once under its own basename.

- Same basename in both `output/` and `output/fixed/` → the `output/fixed/` copy is used, the `output/` one ignored.
- Basename only in `output/` → kept.
- Only `output/` and `output/fixed/` are considered; other subdirectories (e.g. `reports/`) are ignored.

Sources are resolved **before** copying (rather than copying `output/` then overwriting with `fixed/`) because the job output lives on a shared filesystem and may be **read-only** — overwriting a read-only file in place would raise `EACCES`. (Caught by review; there's a regression test with read-only inputs.)

## Test

`bin/rails test` → 50 pass. Adds model tests for: fixed-over-output preference, read-only inputs, keeping unmatched output files, and ignoring non-`fixed` subdirectories.

### Verify against the sample jobs
- with `fixed/`: `bd15ebe7-aba6-4a41-9fa5-a53996439150` (1), `9d2fe944-484d-400f-a3f6-2fb4761387e5` (6)
- without `fixed/`: `9e8c8553-4cc3-4691-9e16-8561e28625f3` (1), `a394a420-2096-4837-8485-a1c35a0e74ef` (3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)