### PR TITLE
Restore the GGS import in the submission form

### DIFF
--- a/web/app/components/submission-form/files.gts
+++ b/web/app/components/submission-form/files.gts
@@ -179,6 +179,21 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
               <div class="form-check">
                 <group.radio as |radio|>
                   <radio.input
+                    checked={{eq @model.uploadVia "ggs"}}
+                    required
+                    class="form-check-input"
+                    {{on "change" (fn this.setUploadVia "ggs")}}
+                  />
+
+                  <radio.label class="form-check-label">
+                    {{t "submission-form.files.a4"}}
+                  </radio.label>
+                </group.radio>
+              </div>
+
+              <div class="form-check">
+                <group.radio as |radio|>
+                  <radio.input
                     checked={{eq @model.uploadVia "webui"}}
                     required
                     class="form-check-input"
@@ -224,6 +239,13 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
           <JobIdExtractor
             @endpoint="/dfast_extractions"
             @i18nPrefix="dfast-extractor"
+            @onPoll={{this.onExtractProgress}}
+            @crossoverErrors={{this.crossoverErrors}}
+          />
+        {{else if (eq @model.uploadVia "ggs")}}
+          <JobIdExtractor
+            @endpoint="/ggs_extractions"
+            @i18nPrefix="ggs-extractor"
             @onPoll={{this.onExtractProgress}}
             @crossoverErrors={{this.crossoverErrors}}
           />

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -142,6 +142,21 @@ export default class UploadFormComponent extends Component<Signature> {
                   <div class="form-check">
                     <group.radio as |radio|>
                       <radio.input
+                        checked={{eq this.uploadVia "ggs"}}
+                        required
+                        class="form-check-input"
+                        {{on "change" (fn this.setUploadVia "ggs")}}
+                      />
+
+                      <radio.label class="form-check-label">
+                        {{t "submission-form.files.a4"}}
+                      </radio.label>
+                    </group.radio>
+                  </div>
+
+                  <div class="form-check">
+                    <group.radio as |radio|>
+                      <radio.input
                         checked={{eq this.uploadVia "webui"}}
                         required
                         class="form-check-input"
@@ -187,6 +202,13 @@ export default class UploadFormComponent extends Component<Signature> {
               <JobIdExtractor
                 @endpoint="/dfast_extractions"
                 @i18nPrefix="dfast-extractor"
+                @onPoll={{this.onExtractProgress}}
+                @crossoverErrors={{this.crossoverErrors}}
+              />
+            {{else if (eq this.uploadVia "ggs")}}
+              <JobIdExtractor
+                @endpoint="/ggs_extractions"
+                @i18nPrefix="ggs-extractor"
                 @onPoll={{this.onExtractProgress}}
                 @crossoverErrors={{this.crossoverErrors}}
               />

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -385,4 +385,129 @@ module('Acceptance | submission', function (hooks) {
 
     assert.ok(document.body.textContent?.includes('NSUB000003'), 'MASS ID is displayed');
   });
+
+  test('new submission via GGS job ID', async function (assert) {
+    const extractionFiles = [
+      {
+        name: 'test.ann',
+        basename: 'test',
+        size: 100,
+        isParsing: false,
+        parsedData: {
+          contactPerson: { fullName: 'Alice Liddell', email: 'alice@example.com', affiliation: 'Wonderland Inc.' },
+          holdDate: null,
+          entriesCount: 0,
+        },
+        isParseSucceeded: true,
+        errors: [],
+        fileType: 'annotation' as const,
+        jobId: '01234567-89ab-cdef-0000-000000000001',
+      },
+      {
+        name: 'test.fa',
+        basename: 'test',
+        size: 50,
+        isParsing: false,
+        parsedData: { entriesCount: 1 },
+        isParseSucceeded: true,
+        errors: [],
+        fileType: 'sequence' as const,
+        jobId: '01234567-89ab-cdef-0000-000000000001',
+      },
+    ];
+
+    worker.use(
+      http.get('/submissions', ({ response }) => {
+        return response(200).json({
+          submissions: [],
+        });
+      }),
+
+      http.get('/submissions/last_submitted', () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+
+      http.post('/ggs_extractions', ({ response }) => {
+        return response(201).json({
+          _self: '/ggs_extractions/1',
+          id: 1,
+          state: 'pending',
+          error: null,
+          files: [],
+        });
+      }),
+
+      http.get('/ggs_extractions/{id}', ({ response }) => {
+        return response(200).json({
+          _self: '/ggs_extractions/1',
+          id: 1,
+          state: 'fulfilled',
+          error: null,
+          files: extractionFiles,
+        });
+      }),
+
+      http.post('/submissions', ({ response }) => {
+        return response(200).json({
+          submission: { id: 'NSUB000004' },
+        });
+      }),
+    );
+
+    // --- Home page ---
+
+    await visit('/home');
+    assert.dom('h1').hasText('Home');
+
+    await click('a[href^="/home/submissions/new"]');
+
+    // --- Step 1: Prerequisite ---
+
+    assert.dom('h1').hasText('New Submission');
+
+    await clickRadio('Yes, I have determined the nucleotide sequence');
+    await click('button[type="submit"]');
+
+    // --- Step 2: Files ---
+
+    await clickRadio('Import the submission files from GGS Job ID');
+    await fillIn('textarea', '01234567-89ab-cdef-0000-000000000001');
+    await click('.card-body button[type="submit"]');
+
+    await waitUntil(() => {
+      return document.querySelectorAll('.list-group-item').length > 0;
+    });
+
+    assert.dom('.list-group-item').exists({ count: 2 });
+
+    await click('button.px-5[type="submit"]');
+
+    // --- Step 3: Metadata ---
+
+    await waitUntil(() => document.querySelector('#entriesCount'));
+
+    assert.dom('#entriesCount').hasValue('1');
+    assert.dom('#contactPerson\\.email').hasValue('alice@example.com');
+    assert.dom('#contactPerson\\.fullName').hasValue('Alice Liddell');
+    assert.dom('#contactPerson\\.affiliation').hasValue('Wonderland Inc.');
+
+    await clickRadio('NGS');
+    await fillIn('#dataType', 'wgs');
+    await clickRadio('English');
+
+    await click('button[type="submit"]');
+
+    // --- Step 4: Confirm ---
+
+    assert.dom('button[type="submit"]').hasText('Apply for registration');
+
+    await click('#agree-terms');
+    await click('button[type="submit"]');
+
+    // --- Step 5: Complete ---
+
+    await waitUntil(() => document.body.textContent?.includes('NSUB000004'));
+
+    assert.ok(document.body.textContent?.includes('NSUB000004'), 'MASS ID is displayed');
+  });
 });

--- a/web/translations/en.yaml
+++ b/web/translations/en.yaml
@@ -104,6 +104,7 @@ submission-form:
       In the case where you upload the submission files, be sure to check the format and/or translation of CDS feature by <a href="https://www.ddbj.nig.ac.jp/ddbj/ume-e.html" target="_blank">UME (Parser, transChecker)</a> and fix the errors. Finally, transfer the submission files having no errors. In order to specify the hold date, you <a href="https://www.ddbj.nig.ac.jp/ddbj/file-format-e.html#date" target="_blank">need to describe the hold_date in COMMON of the annotation file</a>. You cannot specify the hold date by the input area in the form.</p>
 
     a1: Import the submission files from DFAST Job ID.
+    a4: Import the submission files from GGS Job ID.
     a2: Upload the submission files through the MSS form.
 
     a3-html: |
@@ -272,6 +273,15 @@ dfast-extractor:
     You can specify multiple job IDs by delimiting each ID with the line feed.</p>
 
   submit: Retrieve submission files from DFAST
+
+ggs-extractor:
+  ids-label: GGS job IDs
+
+  ids-help-html: |
+    <p>36-digits ID including hyphen. Specify the Job ID of a completed <a href="https://gss.ddbj.nig.ac.jp" target="_blank">GGS (Gene/genome submission tool)</a> job.<br />
+    You can specify multiple job IDs by delimiting each ID with the line feed.</p>
+
+  submit: Retrieve submission files from GGS
 
 submission.show:
   re-upload: Re-upload

--- a/web/translations/ja.yaml
+++ b/web/translations/ja.yaml
@@ -104,6 +104,7 @@ submission-form:
       登録ファイルをアップロードする場合は、事前に<a href="https://www.ddbj.nig.ac.jp/ddbj/ume.html" target="_blank">UME (Parser, transChecker)</a>にてフォーマットやCDSフィーチャーの翻訳チェックを行い、エラーのないファイルを送付してください。公開予定日を指定するには、<a href="https://www.ddbj.nig.ac.jp/ddbj/file-format.html#date" target="_blank">アノテーションファイルCOMMON領域にhold_dateの記載が必要</a>です。フォームへの入力で指定することはできません。</p>
 
     a1: DFASTのジョブIDから登録ファイルを取り込んで送付する
+    a4: GGSのジョブIDから登録ファイルを取り込んで送付する
     a2: 登録ファイルをこのMSSフォームからアップロードする
 
     a3-html: |
@@ -273,6 +274,15 @@ dfast-extractor:
     複数のjob IDを指定する場合は改行で区切ってください。</p>
 
   submit: Retrieve submission files from DFAST
+
+ggs-extractor:
+  ids-label: GGS job IDs
+
+  ids-help-html: |
+    <p>ハイフンを含めた36桁のIDです。<a href="https://gss.ddbj.nig.ac.jp" target="_blank">GGS (Gene/genome submission tool)</a> で完了したジョブのIDを指定してください。<br />
+    複数のjob IDを指定する場合は改行で区切ってください。</p>
+
+  submit: Retrieve submission files from GGS
 
 submission.show:
   re-upload: 再アップロード


### PR DESCRIPTION
Companion to #1555. **Do not merge until the GGS release is coordinated with the other services.**

## What

A clean `git revert` of the removal in #1555. Merging this restores:

- The "import from GGS Job ID" radio option and its `JobIdExtractor` branch in `submission-form/files.gts` and `upload-form.gts`.
- The `ggs-extractor` translations and the `submission-form.files.a4` label (ja/en).
- The GGS acceptance test.

The backend (`GgsExtraction` model, controller, job) was never removed, so this is a frontend-only restore. #1547 (GGS `output/fixed/` priority) can be merged independently before or with this.

## Why a draft

The GGS frontend was withdrawn from `main` so the Terms of Use consent (#1546) could ship first. This PR is held open as the single, clean way to bring GGS back when its coordinated release is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)