### PR TITLE
Reject broken archives instead of crashing the extraction job

### DIFF
--- a/app/jobs/extract_metadata_job.rb
+++ b/app/jobs/extract_metadata_job.rb
@@ -4,6 +4,9 @@ class ExtractMetadataJob < ApplicationJob
       begin
         extraction.prepare_files
       rescue Extraction::Error => e
+        # A partly-processed directory may have created some file records
+        # before failing; discard them so a rejected extraction keeps none.
+        extraction.files.destroy_all
         extraction.update! state: 'rejected', error: {id: e.id, **e.data}
         return
       end

--- a/app/models/concerns/archive_extraction.rb
+++ b/app/models/concerns/archive_extraction.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module ArchiveExtraction
   extend ActiveSupport::Concern
 
@@ -44,13 +46,14 @@ module ArchiveExtraction
         copy_file src_dir, dest_dir, src, &build
       elsif ext = src.match_ext?(ARCHIVE_EXT)
         Dir.mktmpdir do |tmp|
-          tmp  = Pathname.new(tmp)
-          dest = tmp.join(src.to_s.delete_suffix(".#{ext}")).tap(&:mkpath)
+          tmp   = Pathname.new(tmp)
+          input = src_dir.join(src)
+          dest  = tmp.join(src.to_s.delete_suffix(".#{ext}")).tap(&:mkpath)
 
           if src.to_s.end_with?('.zip')
-            system 'unzip', src_dir.join(src).to_s, '-d', dest.to_s, exception: true
+            extract! src, input, 'unzip', input.to_s, '-d', dest.to_s
           else
-            system 'tar', '--extract', '--file', src_dir.join(src).to_s, '--directory', dest.to_s, exception: true
+            extract! src, input, 'tar', '--extract', '--file', input.to_s, '--directory', dest.to_s
           end
 
           unarchive_and_copy_files tmp, dest_dir, &build
@@ -59,16 +62,35 @@ module ArchiveExtraction
         comp_ext = ext.split('.').last
 
         Dir.mktmpdir do |tmp|
-          tmp  = Pathname.new(tmp)
-          dest = tmp.join(src.dirname).tap(&:mkpath)
+          tmp   = Pathname.new(tmp)
+          input = tmp.join(src)
+          dest  = tmp.join(src.dirname).tap(&:mkpath)
 
           FileUtils.cp src_dir.join(src), dest
-          system(*COMPRESS.fetch(comp_ext), tmp.join(src).to_s, exception: true)
+          extract! src, input, *COMPRESS.fetch(comp_ext), input.to_s
 
           copy_file tmp, dest_dir, src.to_s.delete_suffix(".#{comp_ext}"), &build
         end
       end
     end
+  end
+
+  # Run an archive/decompression command on a user-supplied file. A broken or
+  # unsupported input makes the command exit non-zero; surface that as an
+  # Extraction::Error so the job rejects the extraction and shows the reason to
+  # the user, instead of crashing with an opaque error. A genuinely missing
+  # binary still raises Errno::ENOENT so it reaches Sentry as a deployment bug.
+  def extract!(name, input, *command)
+    _out, err, status = Open3.capture3(*command)
+
+    return if status.success?
+
+    # Report the first meaningful line, rewriting the internal temp/mass-dir
+    # path to the file's own name so we never leak server paths to the user.
+    detail = err.gsub(input.to_s, name.to_s).each_line.map(&:strip).find(&:present?)
+    detail ||= "#{command.first} exited with status #{status.exitstatus}"
+
+    raise Extraction::Error.new(:invalid_archive, reason: "#{name}: #{detail}")
   end
 
   def copy_file(base, dest_dir, src, &build)

--- a/test/jobs/extract_metadata_job_test.rb
+++ b/test/jobs/extract_metadata_job_test.rb
@@ -267,4 +267,25 @@ class ExtractMetadataJobTest < ActiveJob::TestCase
       'value'    => nil
     ], file._errors
   end
+
+  test 'archive: broken' do
+    write_file 'aaa.ann', <<~ANN
+      COMMON\tSUBMITTER\t\tcontact\tAlice Liddell
+      \t\t\temail\talice@example.com
+      \t\t\tinstitute\tWonderland Inc.
+    ANN
+
+    write_file 'zzz.tar', 'this is not a tar archive'
+
+    ExtractMetadataJob.perform_now @extraction
+
+    @extraction.reload
+
+    assert_equal 'rejected', @extraction.state
+    assert_equal 'invalid_archive', @extraction.error['id']
+    assert_match(/\Azzz\.tar: /, @extraction.error['reason'])
+
+    # aaa.ann is copied before zzz.tar fails; the rejection must keep no files.
+    assert_empty @extraction.files
+  end
 end

--- a/web/app/components/mass-directory-extractor.gts
+++ b/web/app/components/mass-directory-extractor.gts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
+import { service } from '@ember/service';
 import { modifier } from 'ember-modifier';
 import { tracked } from '@glimmer/tracking';
 
@@ -9,6 +10,7 @@ import userMassDir from 'mssform/helpers/user-mass-dir';
 import Extraction from 'mssform/models/extraction';
 
 import type { ExtractionPayload } from 'mssform/models/extraction';
+import type ErrorModalService from 'mssform/services/error-modal';
 import type { SubmissionFileData, SubmissionError } from 'mssform/models/submission-file';
 
 export interface Signature {
@@ -19,6 +21,8 @@ export interface Signature {
 }
 
 export default class MassDirectoryExtractorComponent extends Component<Signature> {
+  @service declare errorModal: ErrorModalService;
+
   @tracked files: SubmissionFileData[] = [];
 
   fetchFiles = modifier(() => {
@@ -33,7 +37,9 @@ export default class MassDirectoryExtractorComponent extends Component<Signature
 
           this.args.onPoll(payload);
         },
-        undefined,
+        (error) => {
+          this.errorModal.show(new Error(error.reason ?? error.id));
+        },
         abort.signal,
       );
     })().catch((e) => {


### PR DESCRIPTION
## Problem

Sentry **MSSFORM-68** (`RuntimeError: Command failed with exit 2: tar`, culprit `ExtractMetadataJob`) fires whenever a mass-directory upload contains a file with an archive extension whose contents are *not* a valid archive.

`ArchiveExtraction#unarchive_and_copy_files` ran the extractor via `system('tar', …, exception: true)`. On a broken input tar exits `2` and `system` raises a bare `RuntimeError` — which is **not** an `Extraction::Error`, so it bypasses the job's `rescue Extraction::Error` handler. The result: the job crashes into Sentry as a High-priority internal error instead of rejecting the extraction, and tar's stderr (`This does not look like a tar archive`) is discarded, so the real cause is invisible.

(For the record: `tar` is present in the image — a missing binary would raise `Errno::ENOENT`, a different message. The failure is a bad input file, not a missing tool.)

## Changes

- **`extract!` helper** — wraps the archive/decompression commands, runs them via `Open3.capture3`, and on non-zero exit raises `Extraction::Error(:invalid_archive)` with the captured reason. The job already turns `Extraction::Error` into a `rejected` state with a user-facing message, so broken uploads no longer reach Sentry. A genuinely missing binary still raises `Errno::ENOENT`, so real deployment bugs keep surfacing.
- **No path leak** — the internal temp/mass-dir path in the reported reason is rewritten to the file's own name, and only the first meaningful stderr line is kept (e.g. `zzz.tar: tar: This does not look like a tar archive`).
- **No orphaned files** — a partly-processed directory could already have created some `ExtractionFile` records before the failure; the rejection path now discards them so a rejected extraction keeps none. This was latent for every `Extraction::Error` path (e.g. duplicate file names), not just archives.
- **Frontend** — the mass-directory extractor's `onError` was `undefined`, so even existing rejections showed nothing. Wired it to the error modal, matching the job-id extractor.

## Testing

- `bin/rails test` — 51 runs, 0 failures. New `archive: broken` test asserts the job rejects (not crashes), reports a reason, and keeps no files (a valid file is processed before the broken archive to guard the orphan-cleanup path).
- `cd web && pnpm lint && pnpm test:ember` — clean, 26 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)