### PR TITLE
Reject unreadable files instead of crashing the extraction job

### DIFF
--- a/app/models/concerns/archive_extraction.rb
+++ b/app/models/concerns/archive_extraction.rb
@@ -94,12 +94,21 @@ module ArchiveExtraction
   end
 
   def copy_file(base, dest_dir, src, &build)
-    name = normalize_path(src)
-    dest = dest_dir.join(name)
+    name   = normalize_path(src)
+    dest   = dest_dir.join(name)
+    source = base.join(src)
 
     raise Extraction::Error.new(:duplicate_file_name, reason: "duplicate file name: #{name}") if dest.exist?
 
-    FileUtils.cp base.join(src), dest
+    # A broken symlink or otherwise unreadable entry in the user's directory
+    # should reject the extraction with the offending name, not crash the job.
+    unless source.file? && source.readable?
+      detail = source.symlink? && !source.exist? ? 'broken symlink' : 'not a readable file'
+
+      raise Extraction::Error.new(:unreadable_file, reason: "#{src}: #{detail}")
+    end
+
+    FileUtils.cp source, dest
 
     build.call name
   end

--- a/test/jobs/extract_metadata_job_test.rb
+++ b/test/jobs/extract_metadata_job_test.rb
@@ -288,4 +288,26 @@ class ExtractMetadataJobTest < ActiveJob::TestCase
     # aaa.ann is copied before zzz.tar fails; the rejection must keep no files.
     assert_empty @extraction.files
   end
+
+  test 'archive: unreadable file (broken symlink)' do
+    write_file 'aaa.ann', <<~ANN
+      COMMON\tSUBMITTER\t\tcontact\tAlice Liddell
+      \t\t\temail\talice@example.com
+      \t\t\tinstitute\tWonderland Inc.
+    ANN
+
+    dir = Rails.application.config_for(:app).mass_dir_path_template!.gsub('{user}', 'alice')
+    File.symlink '/nonexistent/target.ann', File.join(dir, 'zzz.ann')
+
+    ExtractMetadataJob.perform_now @extraction
+
+    @extraction.reload
+
+    assert_equal 'rejected', @extraction.state
+    assert_equal 'unreadable_file', @extraction.error['id']
+    assert_equal 'zzz.ann: broken symlink', @extraction.error['reason']
+
+    # aaa.ann is copied before zzz.ann fails; the rejection must keep no files.
+    assert_empty @extraction.files
+  end
 end


### PR DESCRIPTION
## Problem

Sentry **MSSFORM-69** (`Errno::ENOENT: No such file or directory @ rb_sysopen`, culprit `ExtractMetadataJob`) fired when a mass-directory upload contained a **broken symlink** — a file with a submission extension (`…/mass/CREV_r1.0.register.ann`) whose target does not exist.

`Dir.glob` in `ArchiveExtraction#unarchive_and_copy_files` matches the symlink by name, and `copy_file` then runs `FileUtils.cp`, which dereferences it and raises `Errno::ENOENT`. That is not an `Extraction::Error`, so it bypasses `ExtractMetadataJob`'s `rescue` handler and crashes the job into Sentry as a High-priority internal error instead of rejecting the extraction. (This is the sibling of #1584, which fixed the same class of crash for broken archives.)

## Change

`copy_file` now guards the source with `file? && readable?` before copying, and raises `Extraction::Error(:unreadable_file, reason:)` otherwise — so the job marks the extraction `rejected` with the offending file name and a user-facing reason, distinguishing a `broken symlink` from an otherwise `not a readable file` entry.

The guard inspects **only the source**, before the copy, so genuine dest-side/server failures (e.g. a full disk during the write) still propagate and reach Sentry rather than being mislabeled as a user error.

## Testing

- `bin/rails test` — 52 runs, 0 failures. New `archive: unreadable file (broken symlink)` test stages a valid `aaa.ann` **before** a broken `zzz.ann` symlink, then asserts the job rejects with `unreadable_file` (`zzz.ann: broken symlink`) and keeps **no** files (the valid file created before the failure is cleaned up). Verified the test reproduces the exact MSSFORM-69 crash when the guard is removed.
- `bin/rubocop` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)