### PR TITLE
Reject duplicate DFAST file names instead of crashing the extraction job

### DIFF
--- a/app/models/dfast_extraction.rb
+++ b/app/models/dfast_extraction.rb
@@ -27,6 +27,10 @@ class DfastExtraction < ApplicationRecord
 
       dest_name = normalize_path(entry.name)
 
+      # Different DFAST jobs can contain a file with the same name; reject the
+      # collision with the offending name instead of hitting the unique index.
+      raise Extraction::Error.new(:duplicate_file_name, reason: "duplicate file name: #{dest_name}") if files.exists?(name: dest_name)
+
       working_dir.join(dest_name).open 'w' do |dest|
         IO.copy_stream entry.get_input_stream, dest
 

--- a/test/models/dfast_extraction_test.rb
+++ b/test/models/dfast_extraction_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+class DfastExtractionTest < ActiveSupport::TestCase
+  def zip_with(*names)
+    Zip::OutputStream.write_buffer {|io|
+      names.each do |name|
+        io.put_next_entry name
+        io.write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+      end
+    }.string
+  end
+
+  def stub_fetch(body, &)
+    response = Struct.new(:ok, :body).new(true, body)
+
+    Fetch::API.stub(:fetch, ->(*) { response }, &)
+  end
+
+  test 'prepare_files copies each zip entry and tags it with the job ID' do
+    job1 = '01234567-89ab-cdef-0000-000000000001'
+    job2 = '01234567-89ab-cdef-0000-000000000002'
+
+    extraction = DfastExtraction.create!(user: users(:alice), dfast_job_ids: [job1, job2])
+
+    responses = {
+      job1 => zip_with('a.ann', 'a.fasta'),
+      job2 => zip_with('b.ann', 'b.fasta')
+    }
+
+    Fetch::API.stub :fetch, ->(url) { Struct.new(:ok, :body).new(true, responses.fetch(url[%r{download/([^/]+)/}, 1])) } do
+      extraction.prepare_files
+    end
+
+    assert_equal %w[a.ann a.fasta b.ann b.fasta], extraction.files.order(:name).map(&:name)
+    assert_equal [job1, job1, job2, job2],         extraction.files.order(:name).map(&:dfast_job_id)
+  end
+
+  test 'prepare_files rejects the same file name coming from two jobs' do
+    job1 = '01234567-89ab-cdef-0000-000000000001'
+    job2 = '01234567-89ab-cdef-0000-000000000002'
+
+    extraction = DfastExtraction.create!(user: users(:alice), dfast_job_ids: [job1, job2])
+
+    stub_fetch zip_with('SAMD01943820_unspecified.ann') do
+      error = assert_raises Extraction::Error do
+        extraction.prepare_files
+      end
+
+      assert_equal :duplicate_file_name,                              error.id
+      assert_equal 'duplicate file name: SAMD01943820_unspecified.ann', error.data[:reason]
+    end
+  end
+
+  test 'prepare_files rejects when a job download fails' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+
+    extraction = DfastExtraction.create!(user: users(:alice), dfast_job_ids: [job_id])
+
+    response = Struct.new(:ok, :status, :status_text).new(false, 404, 'Not Found')
+
+    Fetch::API.stub :fetch, ->(*) { response } do
+      error = assert_raises Extraction::Error do
+        extraction.prepare_files
+      end
+
+      assert_equal :failed_to_fetch, error.id
+      assert_equal job_id,           error.data[:job_id]
+      assert_equal '404 Not Found',  error.data[:reason]
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Sentry **MSSFORM-4K** (34 events, ongoing): `ActiveRecord::RecordNotUnique: PG::UniqueViolation` on `index_dfast_extraction_files_on_extraction_id_and_name`, culprit `ExtractMetadataJob`.

`DfastExtraction#prepare_files` loops over the extraction's `dfast_job_ids`, fetches each DFAST job's `ddbj_submission.zip`, and creates a `DfastExtractionFile` per `.ann`/`.fasta` entry. When two different jobs (or two entries) yield the same normalized file name, the second `files.create!` violates the `(extraction_id, name)` unique index and crashes the job with an unhandled `RecordNotUnique` — surfacing in Sentry as a High-priority internal error (`DETAIL: Key (extraction_id, name)=(…, SAMD01943820_unspecified.ann) already exists`) instead of telling the user their jobs contain a colliding file.

## Change

Guard `fetch_and_copy_files` with `files.exists?(name: dest_name)` and raise `Extraction::Error(:duplicate_file_name, reason:)` on a collision, so the job marks the extraction `rejected` with the offending name — the same way `ArchiveExtraction#copy_file` handles it for the mass-directory import (which has the same unique index).

- **DB check, not disk:** `files.exists?` mirrors the unique constraint exactly and is immune to files left in `working_dir` by a rolled-back prior attempt (a disk `exist?` check could falsely reject on retry). The unique index remains the ultimate backstop.
- **First-writer-wins:** the guard runs before the file is written, so a duplicate no longer overwrites the first job's file on disk.
- GGS deliberately differs (no unique index; it allows the same name across jobs via per-job storage) — DFAST keeps its unique-per-extraction contract, so rejecting is the correct behavior here.

## Testing

- New `test/models/dfast_extraction_test.rb` (stubs `Fetch::API`, builds zips with `Zip::OutputStream`): happy path across two jobs, duplicate-name rejection (`duplicate_file_name`), and a download-failure rejection (`failed_to_fetch`). Verified the duplicate test reproduces the exact `RecordNotUnique` crash when the guard is removed.
- `bin/rails test` — 53 runs, 0 failures. `bin/rubocop` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)