### PR TITLE
Reject invalid extraction job IDs instead of crashing the job

### DIFF
--- a/app/models/concerns/extraction.rb
+++ b/app/models/concerns/extraction.rb
@@ -1,6 +1,11 @@
 module Extraction
   extend ActiveSupport::Concern
 
+  # DFAST/GGS job IDs are UUIDs that become path segments in the job's URL or
+  # output directory. Reject malformed values so a stray space or truncated ID
+  # can't crash the extraction with a URI parse error.
+  UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
   class Error < StandardError
     def initialize(id, **data)
       super()

--- a/app/models/dfast_extraction.rb
+++ b/app/models/dfast_extraction.rb
@@ -16,6 +16,8 @@ class DfastExtraction < ApplicationRecord
   private
 
   def fetch_and_copy_files(job_id)
+    raise Extraction::Error.new(:invalid_job_id, job_id:, reason: "invalid job ID: #{job_id}") unless job_id.match?(UUID_FORMAT)
+
     res = Fetch::API.fetch("https://dfast.ddbj.nig.ac.jp/analysis/download/#{job_id}/ddbj_submission.zip")
 
     raise Extraction::Error.new(:failed_to_fetch, job_id:, reason: "#{res.status} #{res.status_text}") unless res.ok

--- a/app/models/ggs_extraction.rb
+++ b/app/models/ggs_extraction.rb
@@ -2,15 +2,7 @@ class GgsExtraction < ApplicationRecord
   include Extraction
   include ArchiveExtraction
 
-  UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
-
   validates :ggs_job_ids, presence: true
-
-  validate do
-    next if ggs_job_ids.blank?
-
-    errors.add :ggs_job_ids, :invalid unless ggs_job_ids.all? { _1.match?(UUID_FORMAT) }
-  end
 
   def prepare_files
     ActiveRecord::Base.transaction do
@@ -23,6 +15,8 @@ class GgsExtraction < ApplicationRecord
   private
 
   def copy_job_files(job_id)
+    raise Extraction::Error.new(:invalid_job_id, job_id:, reason: "invalid job ID: #{job_id}") unless job_id.match?(UUID_FORMAT)
+
     src_dir = job_output_dir(job_id)
 
     raise Extraction::Error.new(:directory_not_found, job_id:) unless src_dir.directory?

--- a/test/models/dfast_extraction_test.rb
+++ b/test/models/dfast_extraction_test.rb
@@ -68,4 +68,16 @@ class DfastExtractionTest < ActiveSupport::TestCase
       assert_equal '404 Not Found',  error.data[:reason]
     end
   end
+
+  test 'prepare_files rejects a malformed job ID before building the download URL' do
+    # A job ID with an embedded space becomes an invalid download URL and used
+    # to crash the job with URI::InvalidURIError (MSSFORM-5Z).
+    extraction = DfastExtraction.create!(user: users(:alice), dfast_job_ids: ['838b545-ad30-4c3d-b238-2b42377a13e0 S'])
+
+    error = assert_raises Extraction::Error do
+      extraction.prepare_files
+    end
+
+    assert_equal :invalid_job_id, error.id
+  end
 end

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -184,11 +184,14 @@ class GgsExtractionTest < ActiveSupport::TestCase
     assert_equal %w[foo.ann foo.fa], extraction.files.order(:name).map(&:name)
   end
 
-  test 'rejects non-UUID job IDs' do
-    extraction = GgsExtraction.new(user: users(:alice), ggs_job_ids: ['not-a-uuid'])
+  test 'prepare_files rejects a malformed job ID' do
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: ['not-a-uuid'])
 
-    assert_not extraction.valid?
-    assert_includes extraction.errors[:ggs_job_ids], 'is invalid'
+    error = assert_raises Extraction::Error do
+      extraction.prepare_files
+    end
+
+    assert_equal :invalid_job_id, error.id
   end
 
   test 'rejects blank job IDs without raising' do


### PR DESCRIPTION
## Problem

Sentry **MSSFORM-5Z**: `URI::InvalidURIError: bad URI (is not URI?): "https://dfast.ddbj.nig.ac.jp/analysis/download/838b545-ad30-4c3d-b238-2b42377a13e0 S/ddbj_submission.zip"`, culprit `ExtractMetadataJob`.

A user submitted a DFAST job ID with an embedded space (a mis-pasted / truncated UUID). `DfastExtraction#fetch_and_copy_files` interpolates the raw job ID into the download URL, and `Fetch::API.fetch` runs `URI.parse` on it → unhandled `URI::InvalidURIError` → the job crashes into Sentry.

## Change

Validate the job ID against the canonical UUID format (the UI documents a "36-digit ID including hyphen") **before** it becomes a URL/path segment, and raise `Extraction::Error(:invalid_job_id, job_id:, reason:)` on a mismatch. `ExtractMetadataJob` already rescues `Extraction::Error` → marks the extraction `rejected` with a user-facing reason (shown in DFAST's existing error modal), the same way `:failed_to_fetch` and `:duplicate_file_name` are handled — so the bad input is reported to the user and **never reaches Sentry**.

### Why not a model-level `validates` + `create!`

Because it wouldn't remove the Sentry noise. This app runs sentry-rails with `report_rescued_exceptions` at its default (`true`), and `ActiveRecord::RecordInvalid` is **not** in sentry-rails' ignore list — so a `create!`-raised `RecordInvalid` (even though it maps to HTTP 422) is still reported to Sentry. Handling it as an `Extraction::Error` inside the job (which the job catches and never re-raises) eliminates the report entirely, and reuses the extraction-rejected UX that already exists.

### GGS

GGS shares the same UUID format and had the identical exposure via its own model validation (`create!` → `RecordInvalid` → still reported). Both extraction types now guard at the job level through the shared `Extraction::UUID_FORMAT`, so GGS is consistent and won't add the same noise when its frontend is restored.

## Testing

- `test/models/dfast_extraction_test.rb`: a space-containing job ID makes `prepare_files` raise `Extraction::Error(:invalid_job_id)`. Verified it reproduces the exact `URI::InvalidURIError` when the guard is removed.
- `test/models/ggs_extraction_test.rb`: the existing "rejects non-UUID job IDs" test now asserts the job-level `:invalid_job_id` rejection.
- `bin/rails test` — 56 runs, 0 failures. `bin/rubocop` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)