### PR TITLE
Emit production source maps for Sentry de-minification

### DIFF
--- a/web/vite.config.mjs
+++ b/web/vite.config.mjs
@@ -4,6 +4,13 @@ import { babel } from '@rollup/plugin-babel';
 import { loadTranslations } from '@ember-intl/vite';
 
 export default defineConfig({
+  // Emit source maps so Sentry can de-minify production stack traces. The app
+  // is served over a public path, so Sentry resolves the .map files from their
+  // sourceMappingURL — no upload step or auth token required.
+  build: {
+    sourcemap: true,
+  },
+
   plugins: [
     classicEmberSupport(),
     ember(),


### PR DESCRIPTION
## Why

Frontend Sentry issues (e.g. **MSSFORM-66** `isActiveIntent` / **MSSFORM-60** `submit`) arrive with fully minified stack traces — `main-*.js` with single-letter frame names — so they can't be diagnosed. The build currently emits no source maps.

## Change

Enable Vite source maps (`build.sourcemap: true`). The build now emits `*.js.map` alongside each chunk, with a `//# sourceMappingURL=` comment. Because the app's assets are served over a **public path without auth** (`before_action :authenticate!` only guards the API controllers; static assets go through Rails' public file server), Sentry resolves the maps directly from their URL — **no `@sentry/vite-plugin`, upload step, or auth token in the Docker build required**.

The `.map` files are only fetched by Sentry's backend (and browser devtools when open), never during a normal page load, so there's no user-facing performance impact.

## Notes

- This is forward-looking: it makes **future** frontend events readable. It cannot retroactively de-minify the already-captured MSSFORM-66/60 events (those reference older asset hashes).
- If private source maps are ever preferred over publicly-served ones, the alternative is `@sentry/vite-plugin` uploading maps at build time (needs `SENTRY_AUTH_TOKEN` as a Docker build secret) — not done here to keep the build credential-free.

## Testing

- `pnpm build` — emits `dist/assets/main-*.js.map` with the `sourceMappingURL` comment.
- `pnpm lint` (incl. Glint) and `pnpm test:ember` (26 tests) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)