### PR TITLE
Don't leak expected extraction rejections as unhandled rejections

### DIFF
--- a/web/app/services/error-modal.ts
+++ b/web/app/services/error-modal.ts
@@ -8,7 +8,5 @@ export default class ErrorModalService extends Service {
     const controller = getOwner(this)!.lookup('controller:application') as ApplicationController;
 
     controller.showErrorModal(error);
-
-    throw error;
   }
 }

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -510,4 +510,55 @@ module('Acceptance | submission', function (hooks) {
 
     assert.ok(document.body.textContent?.includes('NSUB000004'), 'MASS ID is displayed');
   });
+
+  test('a rejected extraction shows the error modal instead of leaking an unhandled rejection', async function (assert) {
+    worker.use(
+      http.get('/submissions', ({ response }) => {
+        return response(200).json({
+          submissions: [],
+        });
+      }),
+
+      http.get('/submissions/last_submitted', () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+
+      http.post('/dfast_extractions', ({ response }) => {
+        return response(201).json({
+          _self: '/dfast_extractions/1',
+          id: 1,
+          state: 'pending',
+          error: null,
+          files: [],
+        });
+      }),
+
+      http.get('/dfast_extractions/{id}', ({ response }) => {
+        return response(200).json({
+          _self: '/dfast_extractions/1',
+          id: 1,
+          state: 'rejected',
+          error: { id: 'failed_to_fetch', job_id: '01234567-89ab-cdef-0000-000000000001', reason: '404 Not Found' },
+          files: [],
+        });
+      }),
+    );
+
+    await visit('/home');
+
+    await click('a[href^="/home/submissions/new"]');
+
+    await clickRadio('Yes, I have determined the nucleotide sequence');
+    await click('button[type="submit"]');
+
+    await clickRadio('Import the submission files from DFAST Job ID');
+    await fillIn('textarea', '01234567-89ab-cdef-0000-000000000001');
+    await click('.card-body button[type="submit"]');
+
+    await waitUntil(() => document.querySelector('.modal-body p')?.textContent);
+
+    // A rejected extraction is an expected user error: it must surface in the
+    // error modal, not escape as an unhandled rejection (which fails this test).
+    assert.dom('.modal-body p').hasText('404 Not Found');
+  });
 });


### PR DESCRIPTION
## Problem

Sentry **MSSFORM-65 / 5X**: `Error: directory_not_found` reported as an `onunhandledrejection`, culprit `route:submissions.new` / `pollForResult`.

`directory_not_found` is a legitimate `Extraction::Error` (a GGS job's output directory isn't found) — and by the same mechanism, *every* extraction rejection (`invalid_archive`, `unreadable_file`, `duplicate_file_name`, `failed_to_fetch`, `invalid_job_id`). The backend rejects the extraction cleanly and the frontend shows an error modal, yet the error **also leaked to Sentry** as an unhandled promise rejection.

### Root cause

`ErrorModalService#show(error)` displayed the modal **and then `throw error`**. The extractor components' `onError` callbacks call `errorModal.show(new Error(error.reason ?? error.id))` purely to display the modal:

```js
// pollForResult: case 'rejected': onError?.(payload.error!); return;
// onError:       (error) => { this.errorModal.show(...); }   // show() threw!
```

So the throw propagated out of `pollForResult`'s rejected branch → out of the component's async `extract()` action → unhandled rejection → Sentry.

## Change

Remove the `throw error` from `show()` so it only displays the modal. The one caller that needs propagation — the RequestManager `ErrorModalHandler` — already has its own `throw e` (which was *dead code* while `show` threw first, and is now live with an identical net effect). So genuine request failures (a failed POST, a network error) still surface in the modal **and** propagate/report exactly as before; only the expected `state: 'rejected'` path stops leaking.

## Testing

- New acceptance test: a DFAST extraction that polls to `state: 'rejected'` shows the error modal (`.modal-body p` = the reason) and does **not** fail via an unhandled rejection. Verified it fails with the old `throw` in place and passes with it removed. GGS/mass-directory reuse the same mechanism.
- `pnpm lint` (incl. Glint) and `pnpm test:ember` (27 tests) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)