### PR TITLE
Don't report request failures to Sentry as client-side crashes

### DIFF
--- a/web/app/app.ts
+++ b/web/app/app.ts
@@ -2,6 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
+import isRequestError from 'mssform/utils/is-request-error';
 import { importSync, isDevelopingApp, isTesting, macroCondition } from '@embroider/macros';
 
 if (macroCondition(isTesting())) {
@@ -19,6 +20,15 @@ if (macroCondition(isTesting())) {
       dsn,
       environment: document.querySelector('meta[name="sentry-environment"]')?.getAttribute('content') ?? undefined,
       sendDefaultPii: true,
+
+      beforeSend(event, hint) {
+        // Request failures are already shown to the user by the error-modal
+        // handler (and server errors are captured on the backend), so an
+        // uncaught one is expected noise here, not a client-side crash.
+        if (isRequestError(hint?.originalException)) return null;
+
+        return event;
+      },
     });
   }
 }

--- a/web/app/utils/is-request-error.ts
+++ b/web/app/utils/is-request-error.ts
@@ -1,0 +1,7 @@
+// Errors thrown by the RequestManager fetch chain carry `isRequestError`
+// (HTTP status errors, network failures, aborts). They are already surfaced to
+// the user by the error-modal handler — and server errors are captured on the
+// backend — so they should not be reported to Sentry as client-side crashes.
+export default function isRequestError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'isRequestError' in error && error.isRequestError === true;
+}

--- a/web/tests/unit/utils/is-request-error-test.ts
+++ b/web/tests/unit/utils/is-request-error-test.ts
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+
+import isRequestError from 'mssform/utils/is-request-error';
+
+module('Unit | Utility | is-request-error', function () {
+  test('true for errors thrown by the request chain', function (assert) {
+    const forbidden = Object.assign(new Error('[403 Forbidden] POST - /uploads'), {
+      isRequestError: true,
+      status: 403,
+    });
+
+    assert.true(isRequestError(forbidden));
+  });
+
+  test('false for unexpected client-side errors', function (assert) {
+    // e.g. MSSFORM-60: these must still reach Sentry.
+    assert.false(isRequestError(new TypeError("Cannot read properties of undefined (reading 'id')")));
+    assert.false(isRequestError(new Error('boom')));
+  });
+
+  test('false for non-errors and non-request flags', function (assert) {
+    assert.false(isRequestError(undefined));
+    assert.false(isRequestError(null));
+    assert.false(isRequestError('directory_not_found'));
+    assert.false(isRequestError({ isRequestError: false }));
+  });
+});


### PR DESCRIPTION
## Problem

Sentry **MSSFORM-64**: `ForbiddenError: [403 Forbidden] POST /api/submissions/NSUB003556/uploads`, reported as an `onunhandledrejection`, culprit `route:submission.upload`.

A 403 (the user isn't allowed to upload to that submission) is an **expected** outcome. The RequestManager's error-modal handler already shows it to the user in a modal, then re-throws so the awaiting code skips its success path. But the async action (`upload-form.submit`) doesn't catch the re-thrown error, so it escapes as an unhandled promise rejection and gets reported to Sentry — even though it was already surfaced to the user.

This is the same class as the extraction-rejection leak (#1593) but via a different mechanism: a genuine request error re-thrown up through an uncaught `async` action. It applies to every such flow (submit, upload, extract) and every request-layer failure (4xx, 5xx, network, abort).

## Change

Filter these at the source in `Sentry.init`'s `beforeSend`: any thrown value carrying `isRequestError` (set by `@warp-drive/core`'s fetch chain on all HTTP/network/abort errors) is dropped. Rationale:

- **Already surfaced**: the error-modal handler shows every non-suppressed request error to the user.
- **Server errors are captured on the backend**: a frontend "500 error" report is redundant with the Rails-side Sentry event that has the real stack.
- **Genuine JS bugs still report**: a `TypeError` (e.g. MSSFORM-60) has no `isRequestError` flag, so it is untouched.

The `isRequestError` predicate is a small pure util with a unit test, so the discrimination that keeps real crashes reporting is covered.

## Testing

- New unit test for `isRequestError` (true for a request error, false for `TypeError`/plain `Error`/non-objects).
- `pnpm lint` (incl. Glint) and `pnpm test:ember` (29 tests) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)