### PR TITLE
Surface upload failures instead of leaking them to Sentry

### DIFF
--- a/web/app/components/extracted-files.gts
+++ b/web/app/components/extracted-files.gts
@@ -30,5 +30,5 @@ interface Signature {
 </template> satisfies TOC<Signature>;
 
 function sortByName(files: SubmissionFileData[]) {
-  return files.toSorted((a, b) => a.name.localeCompare(b.name));
+  return [...files].sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/web/app/components/file-list.gts
+++ b/web/app/components/file-list.gts
@@ -59,9 +59,13 @@ export default class FileListComponent extends Component<Signature> {
     for (const file of files) {
       this.args.onAdd(file);
 
-      void file.parse().then(() => {
-        file.calculateDigest();
-      });
+      // A parse failure is surfaced inline via file.errors, and a digest
+      // failure resurfaces when the upload awaits the checksum, so swallow the
+      // rejection here to keep it from escaping as an unhandled rejection.
+      void file
+        .parse()
+        .then(() => file.calculateDigest())
+        .catch(() => {});
     }
   }
 

--- a/web/app/components/submission-form/confirm.gts
+++ b/web/app/components/submission-form/confirm.gts
@@ -41,9 +41,11 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
     const { uploadVia } = model;
 
     if (uploadVia === 'webui') {
-      const blobs = (await uploadProgressModal.performUpload(
-        state.files as SubmissionFile[],
-      )) as unknown as DirectUploadBlob[];
+      const blobs = (await uploadProgressModal.performUpload(state.files as SubmissionFile[])) as unknown as
+        DirectUploadBlob[] | undefined;
+
+      // The upload failed and was surfaced in the error modal; stay on the form.
+      if (!blobs) return;
 
       model.files = blobs.map((blob) => blob.signed_id);
     }

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -85,9 +85,11 @@ export default class UploadFormComponent extends Component<Signature> {
     };
 
     if (this.uploadVia == 'webui') {
-      const blobs = (await uploadProgressModal.performUpload(
-        this.files as SubmissionFile[],
-      )) as unknown as DirectUploadBlob[];
+      const blobs = (await uploadProgressModal.performUpload(this.files as SubmissionFile[])) as unknown as
+        DirectUploadBlob[] | undefined;
+
+      // The upload failed and was surfaced in the error modal; stay on the form.
+      if (!blobs) return;
 
       attrs['files'] = blobs.map((blob) => blob.signed_id);
     } else {

--- a/web/app/components/upload-progress-modal.gts
+++ b/web/app/components/upload-progress-modal.gts
@@ -14,6 +14,7 @@ import percentage from 'mssform/helpers/percentage';
 import UploadFiles from 'mssform/models/upload-files';
 
 import type CurrentUserService from 'mssform/services/current-user';
+import type ErrorModalService from 'mssform/services/error-modal';
 import type { SubmissionFile } from 'mssform/models/submission-file';
 
 interface Signature {
@@ -24,6 +25,7 @@ interface Signature {
 
 export default class UploadProgressModalComponent extends Component<Signature> {
   @service declare currentUser: CurrentUserService;
+  @service declare errorModal: ErrorModalService;
 
   @tracked uploadFiles?: UploadFiles;
 
@@ -37,21 +39,31 @@ export default class UploadProgressModalComponent extends Component<Signature> {
     this.modal.hide();
   }
 
+  // Returns the uploaded blobs, or `undefined` if the upload failed. A failure
+  // (e.g. a dropped connection) is expected, so it is surfaced in the error
+  // modal rather than left to escape as an unhandled rejection; callers must
+  // treat `undefined` as "abort" and not proceed with the submission.
   async performUpload(files: SubmissionFile[]) {
     if (!files.length) return [];
 
     this.uploadFiles = new UploadFiles(files);
     this.modal.show();
 
-    let blobs;
-
     try {
-      blobs = await this.uploadFiles.perform(this.currentUser);
-    } finally {
-      this.modal.hide();
-    }
+      const blobs = await this.uploadFiles.perform(this.currentUser);
 
-    return blobs;
+      this.modal.hide();
+
+      return blobs;
+    } catch (error) {
+      // Hide this modal before showing the error modal. This is only safe while
+      // this modal is not animated (no `fade`), so its backdrop is torn down
+      // synchronously and does not race the error modal's backdrop.
+      this.modal.hide();
+      this.errorModal.show(error as Error);
+
+      return undefined;
+    }
   }
 
   <template>

--- a/web/app/models/direct-upload.ts
+++ b/web/app/models/direct-upload.ts
@@ -18,7 +18,6 @@ export class DirectUpload {
 
   async create() {
     const blob = new BlobRecord(this.file, await this.checksum, this.url);
-    blob.requestDidError = (event: ProgressEvent) => blob.callback(event.target);
 
     this.delegate.directUploadWillCreateBlobWithXHR!(blob.xhr);
 
@@ -28,7 +27,6 @@ export class DirectUpload {
           reject(new Error(error));
         } else {
           const upload = new BlobUpload(blob);
-          upload.requestDidError = (event: ProgressEvent) => upload.callback(event.target);
 
           this.delegate.directUploadWillStoreFileWithXHR!(upload.xhr);
 

--- a/web/app/models/submission-file.ts
+++ b/web/app/models/submission-file.ts
@@ -152,6 +152,8 @@ export class SubmissionFile implements SubmissionFileData {
 
       worker.postMessage({ file: this.rawFile });
     });
+
+    return this.checksum;
   }
 }
 

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -3,7 +3,8 @@ import { visit, click, triggerEvent, waitUntil, fillIn } from '@ember/test-helpe
 import { setupApplicationTest } from 'mssform/tests/helpers';
 import { setupAuthentication } from 'mssform/tests/helpers/setup-auth';
 
-import { HttpResponse } from 'msw';
+import { HttpResponse, http as mswHttp } from 'msw';
+import ENV from 'mssform/config/environment';
 import { http } from '../msw/http';
 import { worker } from '../msw/worker';
 
@@ -560,5 +561,75 @@ module('Acceptance | submission', function (hooks) {
     // A rejected extraction is an expected user error: it must surface in the
     // error modal, not escape as an unhandled rejection (which fails this test).
     assert.dom('.modal-body p').hasText('404 Not Found');
+  });
+
+  test('a failed webui upload shows the error modal instead of leaking an unhandled rejection', async function (assert) {
+    worker.use(
+      http.get('/submissions', ({ response }) => {
+        return response(200).json({
+          submissions: [],
+        });
+      }),
+
+      http.get('/submissions/last_submitted', () => {
+        return new HttpResponse(null, { status: 404 });
+      }),
+
+      // The direct upload to storage fails mid-submission.
+      mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await visit('/home');
+
+    await click('a[href^="/home/submissions/new"]');
+
+    // --- Step 1: Prerequisite ---
+
+    await clickRadio('Yes, I have determined the nucleotide sequence');
+    await click('button[type="submit"]');
+
+    // --- Step 2: Files ---
+
+    await clickRadio('Upload the submission files through the MSS form');
+
+    const ann = new File(
+      [
+        'COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n\t\t\temail\talice@example.com\n\t\t\tinstitute\tWonderland Inc.\n',
+      ],
+      'test.ann',
+    );
+
+    const seq = new File(['>entry1\nATCG\n'], 'test.fasta');
+
+    await triggerEvent('input[type="file"]', 'change', { files: [ann, seq] });
+
+    await waitUntil(() => document.querySelectorAll('.spinner-border').length === 0);
+
+    await click('button[type="submit"]');
+
+    // --- Step 3: Metadata ---
+
+    await waitUntil(() => document.querySelector('#entriesCount'));
+
+    await clickRadio('NGS');
+    await fillIn('#dataType', 'wgs');
+    await clickRadio('English');
+
+    await click('button[type="submit"]');
+
+    // --- Step 4: Confirm ---
+
+    await click('#agree-terms');
+    await click('button.px-5[type="submit"]');
+
+    await waitUntil(() => document.querySelector('.modal-body p')?.textContent);
+
+    // A failed upload is expected (e.g. a dropped connection): it must surface
+    // in the error modal, not escape as an unhandled rejection (which fails
+    // this test), and the submission must not proceed.
+    assert.dom('.modal-body p').hasText('Error storing "test.ann". Status: 500');
+    assert.dom('button.px-5[type="submit"]').exists('stays on the confirm step');
   });
 });


### PR DESCRIPTION
## Summary

Triaged four new Sentry issues and fixed the three that were real, unhandled frontend crashes:

- **MSSFORM-6D** — `TypeError: e.toSorted is not a function` (`extracted-files.gts`, Chrome 109). `Array.prototype.toSorted` needs Chrome 110+. `sortByName` was the only remaining `toSorted` caller; it now uses `[...files].sort(...)`, matching the defensive copy already used in `file-list.gts`.
- **MSSFORM-6A / 6B** — `network error` / `[object XMLHttpRequest]`. A failed Active Storage direct upload (e.g. a dropped connection) rejected out of the submit action as an unhandled rejection, and `direct-upload.ts` overrode Active Storage's meaningful error message with the raw XHR object.

The fourth, **MSSFORM-6C** (`Cannot read properties of undefined (reading 'name')` inside `router_js`'s `isActiveIntent`), has no clear app-level cause — it looks like a transient during route transition — so it's left to monitor for recurrence.

## Changes

- `upload-progress-modal.gts`: `performUpload` catches upload failures, surfaces them in the error modal, and returns `undefined` so both submit actions abort without proceeding. This follows the existing convention where `errorModal.show()` does not rethrow, so shown errors never become unhandled rejections.
- `upload-form.gts` / `submission-form/confirm.gts`: guard `if (!blobs) return;` after `performUpload` (empty-files still returns `[]`, so only a genuine failure aborts).
- `direct-upload.ts`: removed the `requestDidError` overrides, restoring Active Storage's `Error storing "file". Status: N` messages for both HTTP-error and network-level (status 0) failures.
- `file-list.gts` / `submission-file.ts`: closed a sibling leak — the `parse()` and digest promises spawned at file-add time had no rejection handler, so a worker failure before submit could also escape to Sentry. `parse()` surfaces its error inline and a digest failure resurfaces when the upload awaits the checksum, so the call site now swallows the rejection; `calculateDigest()` returns its promise to make that chain natural.

## Testing

- New acceptance test: a failed webui upload (storage PUT → 500) shows the error modal and stays on the confirm step, instead of leaking an unhandled rejection.
- `pnpm lint` and all 31 Ember tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)