### PR TITLE
Bump brakeman from 8.0.5 to 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     bindata (2.5.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     concurrent-ruby (1.3.8)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,6 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
+ARGV.unshift("--ensure-latest", "7")
 
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
`bin/brakeman` unshifts `--ensure-latest`, so the scan exits 5 as soon as a new brakeman is released -- 8.0.6 landed today and `scan_ruby` now fails on every branch, including the open dependabot PRs.

Note: 8.0.6 no longer reports the `system(*COMPRESS.fetch(...))` command injection in `app/models/concerns/archive_extraction.rb`, so `config/brakeman.ignore` is now listed as an obsolete ignore entry on every run. Left in place for now.