### PR TITLE
Abort the upload when the form is left

### DIFF
--- a/web/app/components/submission-form/confirm.gts
+++ b/web/app/components/submission-form/confirm.gts
@@ -44,7 +44,8 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
       const blobs = (await uploadProgressModal.performUpload(state.files as SubmissionFile[])) as unknown as
         DirectUploadBlob[] | undefined;
 
-      // The upload failed and was surfaced in the error modal; stay on the form.
+      // The upload failed and was surfaced in the error modal, or it was
+      // abandoned along with the form. Either way, stop here.
       if (!blobs) return;
 
       model.files = blobs.map((blob) => blob.signed_id);

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -88,7 +88,8 @@ export default class UploadFormComponent extends Component<Signature> {
       const blobs = (await uploadProgressModal.performUpload(this.files as SubmissionFile[])) as unknown as
         DirectUploadBlob[] | undefined;
 
-      // The upload failed and was surfaced in the error modal; stay on the form.
+      // The upload failed and was surfaced in the error modal, or it was
+      // abandoned along with the form. Either way, stop here.
       if (!blobs) return;
 
       attrs['files'] = blobs.map((blob) => blob.signed_id);

--- a/web/app/components/upload-progress-modal.gts
+++ b/web/app/components/upload-progress-modal.gts
@@ -31,18 +31,28 @@ export default class UploadProgressModalComponent extends Component<Signature> {
 
   modal!: Modal;
 
+  #abort = new AbortController();
+
+  willDestroy() {
+    super.willDestroy();
+
+    // Leaving the form abandons the upload: the browser's back button is not
+    // covered by the `beforeunload` confirmation, and an upload left running
+    // would go on to submit the application from a destroyed component.
+    this.#abort.abort();
+  }
+
   setModal = modifier((element: HTMLElement) => {
     this.modal = new Modal(element);
 
     return () => {
-      // Leaving the form while the upload is running (the browser's back button
-      // is not covered by the `beforeunload` confirmation) destroys this
-      // element without Bootstrap noticing, stranding its backdrop and the
-      // `modal-open` class on `<body>`: the next page would be covered by an
-      // unclickable overlay and unable to scroll. Hiding tears both down
-      // synchronously because this modal is not animated. Disposing is left
-      // out on purpose; it would also drop the application-wide error modal's
-      // window listeners, which share Bootstrap's `.bs.modal` namespace.
+      // Destroying this element while the modal is open leaves Bootstrap
+      // unaware, stranding its backdrop and the `modal-open` class on `<body>`:
+      // the next page would be covered by an unclickable overlay and unable to
+      // scroll. Hiding tears both down synchronously because this modal is not
+      // animated. Disposing is left out on purpose; it would also drop the
+      // application-wide error modal's window listeners, which share
+      // Bootstrap's `.bs.modal` namespace.
       this.modal.hide();
     };
   });
@@ -51,10 +61,11 @@ export default class UploadProgressModalComponent extends Component<Signature> {
     this.modal.hide();
   }
 
-  // Returns the uploaded blobs, or `undefined` if the upload failed. A failure
-  // (e.g. a dropped connection) is expected, so it is surfaced in the error
-  // modal rather than left to escape as an unhandled rejection; callers must
-  // treat `undefined` as "abort" and not proceed with the submission.
+  // Returns the uploaded blobs, or `undefined` if the upload failed or was
+  // abandoned. A failure (e.g. a dropped connection) is expected, so it is
+  // surfaced in the error modal rather than left to escape as an unhandled
+  // rejection; callers must treat `undefined` as "stop here" and not proceed
+  // with the submission.
   async performUpload(files: SubmissionFile[]) {
     if (!files.length) return [];
 
@@ -62,7 +73,7 @@ export default class UploadProgressModalComponent extends Component<Signature> {
     this.modal.show();
 
     try {
-      const blobs = await this.uploadFiles.perform(this.currentUser);
+      const blobs = await this.uploadFiles.perform(this.currentUser, this.#abort.signal);
 
       this.modal.hide();
 
@@ -72,6 +83,10 @@ export default class UploadProgressModalComponent extends Component<Signature> {
       // this modal is not animated (no `fade`), so its backdrop is torn down
       // synchronously and does not race the error modal's backdrop.
       this.modal.hide();
+
+      // The user left the form, so there is nobody left to report to.
+      if (error instanceof DOMException && error.name === 'AbortError') return undefined;
+
       this.errorModal.show(error as Error);
 
       return undefined;

--- a/web/app/models/direct-upload.ts
+++ b/web/app/models/direct-upload.ts
@@ -8,25 +8,48 @@ export class DirectUpload {
   url: string;
   delegate: DirectUploadDelegate;
   checksum: Promise<string>;
+  signal: AbortSignal;
 
-  constructor(file: File, url: string, delegate: DirectUploadDelegate, checksum: Promise<string>) {
+  constructor(file: File, url: string, delegate: DirectUploadDelegate, checksum: Promise<string>, signal: AbortSignal) {
     this.file = file;
     this.url = url;
     this.delegate = delegate;
     this.checksum = checksum;
+    this.signal = signal;
   }
 
   async create() {
-    const blob = new BlobRecord(this.file, await this.checksum, this.url);
+    const { signal } = this;
+    const checksum = await this.checksum;
+
+    signal.throwIfAborted();
+
+    const blob = new BlobRecord(this.file, checksum, this.url);
 
     this.delegate.directUploadWillCreateBlobWithXHR!(blob.xhr);
 
+    let inFlight = blob.xhr;
+    let abortInFlight!: () => void;
+
     return new Promise<Record<string, unknown>>((resolve, reject) => {
+      // Active Storage listens for `load` and `error` only, so an aborted
+      // request would leave this promise pending: reject it here instead, with
+      // the same `AbortError` the fetch-based extractors raise.
+      abortInFlight = () => {
+        inFlight.abort();
+
+        reject(signal.reason as Error);
+      };
+
+      signal.addEventListener('abort', abortInFlight, { once: true });
+
       blob.create((error: string | null) => {
         if (error) {
           reject(new Error(error));
         } else {
           const upload = new BlobUpload(blob);
+
+          inFlight = upload.xhr;
 
           this.delegate.directUploadWillStoreFileWithXHR!(upload.xhr);
 
@@ -39,6 +62,10 @@ export class DirectUpload {
           });
         }
       });
+    }).finally(() => {
+      // Nothing is left to abort, and a finished request must not be touched
+      // when a later file is abandoned.
+      signal.removeEventListener('abort', abortInFlight);
     });
   }
 }

--- a/web/app/models/upload-files.ts
+++ b/web/app/models/upload-files.ts
@@ -23,13 +23,13 @@ export default class UploadFiles {
     return this.uploads.reduce((acc, { uploadedSize }) => acc + uploadedSize, 0);
   }
 
-  async perform(currentUser: CurrentUserService) {
+  async perform(currentUser: CurrentUserService, signal: AbortSignal) {
     const blobs = [];
 
     for (const upload of this.uploads) {
       this.currentUpload = upload;
 
-      blobs.push(await upload.perform(currentUser));
+      blobs.push(await upload.perform(currentUser, signal));
     }
 
     return blobs;
@@ -45,7 +45,7 @@ class UploadFile {
     this.file = file;
   }
 
-  perform(currentUser: CurrentUserService) {
+  perform(currentUser: CurrentUserService, signal: AbortSignal) {
     const upload = new DirectUpload(
       this.file.rawFile,
       ENV.directUploadURL,
@@ -65,6 +65,7 @@ class UploadFile {
         },
       },
       this.file.checksum!,
+      signal,
     );
 
     return upload.create();

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -635,57 +635,74 @@ module('Acceptance | submission', function (hooks) {
     assert.dom('button.px-5[type="submit"]').exists('stays on the confirm step');
   });
 
-  test('leaving the form during an upload takes the progress modal backdrop with it', async function (assert) {
-    let failUpload!: () => void;
+  test('leaving the form during an upload aborts it and takes the backdrop with it', async function (assert) {
+    // Active Storage uploads over XHR, and msw does not tell its handlers when
+    // a client hangs up on one, so count the aborts at the source.
+    let abortedRequests = 0;
+    let uploadStarted = false;
 
-    const uploadFailure = new Promise<void>((resolve) => {
-      failUpload = resolve;
-    });
+    const OriginalXHR = XMLHttpRequest;
 
-    worker.use(
-      http.get('/submissions', ({ response }) => {
-        return response(200).json({
-          submissions: [],
-        });
-      }),
+    window.XMLHttpRequest = class extends OriginalXHR {
+      abort() {
+        abortedRequests += 1;
 
-      http.get('/submissions/last_submitted', () => {
-        return new HttpResponse(null, { status: 404 });
-      }),
+        super.abort();
+      }
+    };
 
-      // The direct upload only answers when this test lets it, so the progress
-      // modal stays open while the form is left.
-      mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, async () => {
-        await uploadFailure;
+    try {
+      worker.use(
+        http.get('/submissions', ({ response }) => {
+          return response(200).json({
+            submissions: [],
+          });
+        }),
 
-        return new HttpResponse(null, { status: 500 });
-      }),
-    );
+        http.get('/submissions/last_submitted', () => {
+          return new HttpResponse(null, { status: 404 });
+        }),
 
-    await fillInWebuiSubmission();
+        // The direct upload never answers, so it is still running when the form
+        // is left. Leaving aborts it, so nothing arrives afterwards.
+        mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, () => {
+          uploadStarted = true;
 
-    // Bootstrap appends the backdrop to `<body>`, outside the application's
-    // root element, so it has to be looked up in the document. Identify it by
-    // what the submit click adds rather than by counting: earlier tests can
-    // leave backdrops of their own behind.
-    const backdrops = new Set(document.querySelectorAll('.modal-backdrop'));
+          return new Promise<Response>(() => {});
+        }),
+      );
 
-    await click('button.px-5[type="submit"]');
+      await fillInWebuiSubmission();
 
-    const backdrop = [...document.querySelectorAll('.modal-backdrop')].find((el) => !backdrops.has(el));
+      // Bootstrap appends the backdrop to `<body>`, outside the application's
+      // root element, so it has to be looked up in the document. Identify it by
+      // what the submit click adds rather than by counting: earlier tests can
+      // leave backdrops of their own behind.
+      const backdrops = new Set(document.querySelectorAll('.modal-backdrop'));
 
-    assert.ok(backdrop, 'the progress modal covers the page while the upload runs');
+      await click('button.px-5[type="submit"]');
 
-    await visit('/home');
+      const backdrop = [...document.querySelectorAll('.modal-backdrop')].find((el) => !backdrops.has(el));
 
-    // Nothing hides the modal when the browser's back button destroys the form
-    // mid-upload, so an unclickable overlay would be left over the next page.
-    assert.notOk(backdrop?.isConnected, 'the backdrop is removed with the form');
+      assert.ok(backdrop, 'the progress modal covers the page while the upload runs');
 
-    // Settle the abandoned upload before the test ends. Left in flight, it
-    // resumes once the owner is destroyed and fails whichever test runs next.
-    failUpload();
+      // Leave only once the file is on its way, so that there is a request to
+      // abort rather than a checksum still being calculated.
+      await waitUntil(() => uploadStarted);
 
-    await waitFor('.modal-body p');
+      await visit('/home');
+
+      // An upload left running would go on to report its outcome on the page
+      // the user moved to, and submit the application from a destroyed
+      // component.
+      assert.strictEqual(abortedRequests, 1, 'the upload is aborted with the form');
+
+      // Nothing hides the modal when the browser's back button destroys the
+      // form mid-upload, so an unclickable overlay would be left over the next
+      // page.
+      assert.notOk(backdrop?.isConnected, 'the backdrop is removed with the form');
+    } finally {
+      window.XMLHttpRequest = OriginalXHR;
+    }
   });
 });

--- a/web/tests/helpers/index.ts
+++ b/web/tests/helpers/index.ts
@@ -7,20 +7,27 @@ import {
 
 import { worker } from '../msw/worker';
 
-function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
-  upstreamSetupApplicationTest(hooks, options);
-
+// Drops the handlers a test installed with `worker.use`, so they cannot answer
+// for the tests that follow.
+function resetHandlers(hooks: NestedHooks) {
   hooks.afterEach(() => {
     worker.resetHandlers();
   });
 }
 
+function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
+  upstreamSetupApplicationTest(hooks, options);
+  resetHandlers(hooks);
+}
+
 function setupRenderingTest(hooks: NestedHooks, options?: SetupTestOptions) {
   upstreamSetupRenderingTest(hooks, options);
+  resetHandlers(hooks);
 }
 
 function setupTest(hooks: NestedHooks, options?: SetupTestOptions) {
   upstreamSetupTest(hooks, options);
+  resetHandlers(hooks);
 }
 
 export { setupApplicationTest, setupRenderingTest, setupTest };

--- a/web/tests/unit/models/annotation-file-test.ts
+++ b/web/tests/unit/models/annotation-file-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'mssform/tests/helpers';
 
 import outdent from 'outdent';
 

--- a/web/tests/unit/models/direct-upload-test.ts
+++ b/web/tests/unit/models/direct-upload-test.ts
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'mssform/tests/helpers';
+
+import { http as mswHttp } from 'msw';
+import ENV from 'mssform/config/environment';
+
+import { DirectUpload } from 'mssform/models/direct-upload';
+import { worker } from '../../msw/worker';
+
+function buildUpload(signal: AbortSignal, willStoreFile: () => void = () => {}) {
+  return new DirectUpload(
+    new File(['>entry1\nATCG\n'], 'test.fasta'),
+    ENV.directUploadURL,
+    {
+      directUploadWillCreateBlobWithXHR: () => {},
+      directUploadWillStoreFileWithXHR: willStoreFile,
+    },
+    Promise.resolve('checksum'),
+    signal,
+  );
+}
+
+function isAbortError(error: Error) {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+module('Unit | Model | direct upload', function (hooks) {
+  setupTest(hooks);
+
+  test('abort before the request is sent', async function (assert) {
+    const abort = new AbortController();
+    const created = buildUpload(abort.signal).create();
+
+    abort.abort();
+
+    await assert.rejects(created, isAbortError);
+  });
+
+  test('abort while the file is being stored', async function (assert) {
+    // Without the fix, `create` never settles: fail fast instead of waiting out
+    // QUnit's default timeout.
+    assert.timeout(1000);
+
+    // The storage request never answers, so the upload is still running when
+    // it is aborted.
+    worker.use(mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, () => new Promise<Response>(() => {})));
+
+    const abort = new AbortController();
+
+    let storing!: () => void;
+
+    const stored = new Promise<void>((resolve) => {
+      storing = resolve;
+    });
+
+    const created = buildUpload(abort.signal, storing).create();
+
+    await stored;
+
+    abort.abort();
+
+    // Active Storage listens for `load` and `error` only, so an aborted
+    // request would leave `create` pending forever.
+    await assert.rejects(created, isAbortError);
+  });
+});

--- a/web/tests/unit/models/sequence-file-test.ts
+++ b/web/tests/unit/models/sequence-file-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'mssform/tests/helpers';
 
 import outdent from 'outdent';
 

--- a/web/tests/unit/models/submission-file-test.ts
+++ b/web/tests/unit/models/submission-file-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'mssform/tests/helpers';
 
 import { SubmissionFile } from 'mssform/models/submission-file';
 


### PR DESCRIPTION
Follow-up to #1622. Hiding the progress modal on teardown took the stranded backdrop with it, but the upload itself kept running after the user left the form (the browser's back button is not covered by the `beforeunload` confirmation). Once the upload finished, `submit` carried on from a destroyed component: on success it posted the application and looked up `service:requestManager` on a destroyed owner, and on failure it popped the error modal over whatever page the user had moved to.

The modal component now owns an `AbortController` and aborts it in `willDestroy`, the way `job-id-extractor` already does for its fetch, and the signal reaches the request through `UploadFiles`. Active Storage listens for `load` and `error` only, so aborting its XHR would leave `DirectUpload#create` pending forever: the signal rejects it with the `AbortError` the controller reports, and `performUpload` treats that as "the user left" rather than something to report.

## Tests

The acceptance test counts aborts through an `XMLHttpRequest` subclass, because msw does not tell its handlers when a client hangs up on an XHR, and it leaves the form only once the upload is on its way so there is a request to abort. `DirectUpload` gets unit tests for both moments an upload can be abandoned: before the request is sent, and while the file is being stored. All three fail when the production change is reverted, and the suite passes 3/3 pinned to a single core (`taskset -c 0`).

## Known gap

The progress modal's own **Cancel** button still only hides the modal: the upload keeps running and, on success, the submission proceeds and the app navigates away under the user. Making Cancel cancel needs a controller per `performUpload` call rather than one per component, so it is left for a follow-up.