### PR TITLE
Make the Cancel button cancel the upload

### DIFF
--- a/web/app/components/submission-form/confirm.gts
+++ b/web/app/components/submission-form/confirm.gts
@@ -45,7 +45,7 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
         DirectUploadBlob[] | undefined;
 
       // The upload failed and was surfaced in the error modal, or it was
-      // abandoned along with the form. Either way, stop here.
+      // cancelled or abandoned along with the form. Either way, stop here.
       if (!blobs) return;
 
       model.files = blobs.map((blob) => blob.signed_id);

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -89,7 +89,7 @@ export default class UploadFormComponent extends Component<Signature> {
         DirectUploadBlob[] | undefined;
 
       // The upload failed and was surfaced in the error modal, or it was
-      // abandoned along with the form. Either way, stop here.
+      // cancelled or abandoned along with the form. Either way, stop here.
       if (!blobs) return;
 
       attrs['files'] = blobs.map((blob) => blob.signed_id);

--- a/web/app/components/upload-progress-modal.gts
+++ b/web/app/components/upload-progress-modal.gts
@@ -31,7 +31,7 @@ export default class UploadProgressModalComponent extends Component<Signature> {
 
   modal!: Modal;
 
-  #abort = new AbortController();
+  #upload = new AbortController();
 
   willDestroy() {
     super.willDestroy();
@@ -39,7 +39,7 @@ export default class UploadProgressModalComponent extends Component<Signature> {
     // Leaving the form abandons the upload: the browser's back button is not
     // covered by the `beforeunload` confirmation, and an upload left running
     // would go on to submit the application from a destroyed component.
-    this.#abort.abort();
+    this.#upload.abort();
   }
 
   setModal = modifier((element: HTMLElement) => {
@@ -57,36 +57,46 @@ export default class UploadProgressModalComponent extends Component<Signature> {
     };
   });
 
-  @action hide() {
+  @action cancel() {
+    // Close right away rather than waiting for the upload to notice: a checksum
+    // still being calculated only sees the abort once it finishes.
+    this.#upload.abort();
     this.modal.hide();
   }
 
-  // Returns the uploaded blobs, or `undefined` if the upload failed or was
-  // abandoned. A failure (e.g. a dropped connection) is expected, so it is
-  // surfaced in the error modal rather than left to escape as an unhandled
-  // rejection; callers must treat `undefined` as "stop here" and not proceed
-  // with the submission.
+  // Returns the uploaded blobs, or `undefined` if the upload failed, was
+  // cancelled or was abandoned. A failure (e.g. a dropped connection) is
+  // expected, so it is surfaced in the error modal rather than left to escape
+  // as an unhandled rejection; callers must treat `undefined` as "stop here"
+  // and not proceed with the submission.
   async performUpload(files: SubmissionFile[]) {
     if (!files.length) return [];
 
+    // A controller per attempt: the one before it may have been cancelled, and
+    // its signal would abort this upload before it starts.
+    this.#upload = new AbortController();
     this.uploadFiles = new UploadFiles(files);
+
     this.modal.show();
 
     try {
-      const blobs = await this.uploadFiles.perform(this.currentUser, this.#abort.signal);
+      const blobs = await this.uploadFiles.perform(this.currentUser, this.#upload.signal);
 
       this.modal.hide();
 
       return blobs;
     } catch (error) {
+      // The user cancelled or left the form, so there is nothing to report --
+      // and both have hidden this modal already. Hiding it again here would
+      // close the modal of a later attempt: an upload cancelled while its
+      // checksum is being calculated only notices the abort once the checksum
+      // finishes, by which time the user may have submitted again.
+      if (error instanceof DOMException && error.name === 'AbortError') return undefined;
+
       // Hide this modal before showing the error modal. This is only safe while
       // this modal is not animated (no `fade`), so its backdrop is torn down
       // synchronously and does not race the error modal's backdrop.
       this.modal.hide();
-
-      // The user left the form, so there is nobody left to report to.
-      if (error instanceof DOMException && error.name === 'AbortError') return undefined;
-
       this.errorModal.show(error as Error);
 
       return undefined;
@@ -151,7 +161,7 @@ export default class UploadProgressModalComponent extends Component<Signature> {
             </div>
 
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" {{on "click" this.hide}}>{{t
+              <button type="button" class="btn btn-secondary" {{on "click" this.cancel}}>{{t
                   "upload-progress-modal.cancel"
                 }}</button>
             </div>

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -1,10 +1,21 @@
 import { module, test } from 'qunit';
-import { visit, click, findAll, getRootElement, triggerEvent, waitFor, waitUntil, fillIn } from '@ember/test-helpers';
+import {
+  visit,
+  click,
+  findAll,
+  getRootElement,
+  settled,
+  triggerEvent,
+  waitFor,
+  waitUntil,
+  fillIn,
+} from '@ember/test-helpers';
 import { setupApplicationTest } from 'mssform/tests/helpers';
 import { setupAuthentication } from 'mssform/tests/helpers/setup-auth';
 
 import { HttpResponse, http as mswHttp } from 'msw';
 import ENV from 'mssform/config/environment';
+import { SubmissionFile } from 'mssform/models/submission-file';
 import { http } from '../msw/http';
 import { worker } from '../msw/worker';
 
@@ -68,6 +79,55 @@ async function fillInWebuiSubmission() {
   // --- Step 4: Confirm ---
 
   await click('#agree-terms');
+}
+
+// Active Storage uploads over XHR, and msw does not tell its handlers when a
+// client hangs up on one, so count the aborts at the source. The caller has to
+// `restore()` whatever happens, or the counting subclass outlives the test.
+function watchAbortedRequests() {
+  const OriginalXHR = XMLHttpRequest;
+
+  const watcher = {
+    count: 0,
+
+    restore() {
+      window.XMLHttpRequest = OriginalXHR;
+    },
+  };
+
+  window.XMLHttpRequest = class extends OriginalXHR {
+    abort() {
+      watcher.count += 1;
+
+      super.abort();
+    }
+  };
+
+  return watcher;
+}
+
+// Holds the digest back, so an upload can be cancelled while its checksum is
+// still being calculated. The caller has to `restore()` whatever happens.
+function stallDigest() {
+  const original = Object.getOwnPropertyDescriptor(SubmissionFile.prototype, 'calculateDigest')!;
+
+  const digest = {
+    finish: undefined as ((checksum: string) => void) | undefined,
+
+    restore() {
+      Object.defineProperty(SubmissionFile.prototype, 'calculateDigest', original);
+    },
+  };
+
+  SubmissionFile.prototype.calculateDigest = function (this: SubmissionFile) {
+    this.checksum = new Promise<string>((resolve) => {
+      digest.finish = resolve;
+    });
+
+    return this.checksum;
+  };
+
+  return digest;
 }
 
 module('Acceptance | submission', function (hooks) {
@@ -636,20 +696,9 @@ module('Acceptance | submission', function (hooks) {
   });
 
   test('leaving the form during an upload aborts it and takes the backdrop with it', async function (assert) {
-    // Active Storage uploads over XHR, and msw does not tell its handlers when
-    // a client hangs up on one, so count the aborts at the source.
-    let abortedRequests = 0;
+    const aborted = watchAbortedRequests();
+
     let uploadStarted = false;
-
-    const OriginalXHR = XMLHttpRequest;
-
-    window.XMLHttpRequest = class extends OriginalXHR {
-      abort() {
-        abortedRequests += 1;
-
-        super.abort();
-      }
-    };
 
     try {
       worker.use(
@@ -695,14 +744,119 @@ module('Acceptance | submission', function (hooks) {
       // An upload left running would go on to report its outcome on the page
       // the user moved to, and submit the application from a destroyed
       // component.
-      assert.strictEqual(abortedRequests, 1, 'the upload is aborted with the form');
+      assert.strictEqual(aborted.count, 1, 'the upload is aborted with the form');
 
       // Nothing hides the modal when the browser's back button destroys the
       // form mid-upload, so an unclickable overlay would be left over the next
       // page.
       assert.notOk(backdrop?.isConnected, 'the backdrop is removed with the form');
     } finally {
-      window.XMLHttpRequest = OriginalXHR;
+      aborted.restore();
+    }
+  });
+
+  test('cancelling an upload stops it and stays on the confirm step', async function (assert) {
+    const aborted = watchAbortedRequests();
+
+    let uploadStarted = false;
+
+    try {
+      worker.use(
+        http.get('/submissions', ({ response }) => {
+          return response(200).json({
+            submissions: [],
+          });
+        }),
+
+        http.get('/submissions/last_submitted', () => {
+          return new HttpResponse(null, { status: 404 });
+        }),
+
+        // The direct upload never answers, so it is still running when it is
+        // cancelled.
+        mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, () => {
+          uploadStarted = true;
+
+          return new Promise<Response>(() => {});
+        }),
+      );
+
+      await fillInWebuiSubmission();
+
+      await click('button.px-5[type="submit"]');
+
+      // Cancel only once the file is on its way, so that there is a request to
+      // abort rather than a checksum still being calculated.
+      await waitUntil(() => uploadStarted);
+
+      await click('.modal-footer button');
+
+      assert.strictEqual(aborted.count, 1, 'the upload is aborted');
+
+      // Cancelling is a choice, not a failure, and it leaves the application
+      // ready to be submitted again.
+      assert.dom('.modal.show').doesNotExist('the progress modal is closed');
+      assert.dom('.modal-body p').doesNotExist('cancelling is not reported as an error');
+      assert.dom('button.px-5[type="submit"]').exists('stays on the confirm step');
+
+      // Submitting again must not inherit the cancelled upload's signal, which
+      // would abort the new one before it starts.
+      worker.use(
+        mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, () => new HttpResponse(null, { status: 204 })),
+
+        http.post('/submissions', ({ response }) => {
+          return response(200).json({
+            submission: { id: 'NSUB000005' },
+          });
+        }),
+      );
+
+      await click('button.px-5[type="submit"]');
+
+      await waitUntil(() => getRootElement().textContent?.includes('NSUB000005'));
+
+      assert.dom().containsText('NSUB000005', 'the application can still be submitted');
+    } finally {
+      aborted.restore();
+    }
+  });
+
+  test('cancelling before the upload starts leaves a later attempt alone', async function (assert) {
+    const digest = stallDigest();
+
+    try {
+      worker.use(
+        http.get('/submissions', ({ response }) => {
+          return response(200).json({
+            submissions: [],
+          });
+        }),
+
+        http.get('/submissions/last_submitted', () => {
+          return new HttpResponse(null, { status: 404 });
+        }),
+
+        // The direct upload never answers, so the second attempt is still
+        // running when the first one is told about the cancellation.
+        mswHttp.put(`${ENV.appURL}/rails/active_storage/disk/*`, () => new Promise<Response>(() => {})),
+      );
+
+      await fillInWebuiSubmission();
+
+      // Cancel while the checksum is still being calculated: this upload only
+      // hears about it once the checksum finishes.
+      await click('button.px-5[type="submit"]');
+      await click('.modal-footer button');
+
+      await click('button.px-5[type="submit"]');
+
+      digest.finish?.('checksum');
+
+      await settled();
+
+      assert.dom('.modal.show').exists('the cancelled upload leaves the running one on screen');
+    } finally {
+      digest.restore();
     }
   });
 });


### PR DESCRIPTION
Follow-up to #1624. The progress modal's Cancel button only closed the modal: the upload kept running behind it and, on success, the application was submitted and the form navigated away under the user -- the opposite of what the button promises.

Cancelling now aborts the upload, over the plumbing that leaving the form already uses. Two details fall out of that:

- The abort is raised before the modal is hidden rather than being left to the upload's own teardown, so cancelling during the checksum phase does not leave the modal on screen until the hash finishes.
- The `AbortController` moves to one per `performUpload` call. The previous attempt's signal is already aborted, so reusing it would abort the next upload before it starts.

An aborted upload also no longer hides the modal on its way out. Both the Cancel button and the form's teardown have hidden it already, and an upload cancelled during its checksum is only told once the checksum finishes -- by then the modal on screen may belong to a later attempt, which would be closed while it keeps uploading. That race was found in review and is covered by a test.

## Tests

Two acceptance tests: cancelling an upload that never answers and then submitting the application again, and cancelling before the upload starts and letting the checksum finish under a second attempt. Each fails against the code it guards, and the suite passes 3/3 pinned to a single core (`taskset -c 0`).

## Not covered

Neither cancelling nor leaving terminates the `calculate-digest.js` Web Worker, so hashing a very large file keeps running after the user has walked away. Pre-existing, and separate from the request plumbing touched here.