### PR TITLE
Stop the workers of files taken off the form

### DIFF
--- a/web/app/components/submission-form.gts
+++ b/web/app/components/submission-form.gts
@@ -12,6 +12,7 @@ import Files from './submission-form/files';
 import Metadata from './submission-form/metadata';
 import Prerequisite from './submission-form/prerequisite';
 import stepNavLinkClass from 'mssform/helpers/step-nav-link-class';
+import { discardFiles } from 'mssform/models/submission-file';
 
 import type { ComponentLike } from '@glint/template';
 import type RouterService from '@ember/routing/router-service';
@@ -37,6 +38,14 @@ export default class SubmissionFormComponent extends Component<Signature> {
 
   state = new State();
   nav = new Navigation();
+
+  willDestroy() {
+    super.willDestroy();
+
+    // The files outlive the step that collected them, so they are discarded
+    // here rather than when the file step is swapped out.
+    discardFiles(this.state.files);
+  }
 
   get component() {
     return COMPONENTS[this.nav.currentStep] as ComponentLike<{

--- a/web/app/components/submission-form/files.gts
+++ b/web/app/components/submission-form/files.gts
@@ -14,6 +14,7 @@ import RadioGroup from 'mssform/components/radio-group';
 import userMassDir from 'mssform/helpers/user-mass-dir';
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
 import OtherPerson from 'mssform/models/other-person';
+import { discardFiles } from 'mssform/models/submission-file';
 
 import type { paths } from 'schema/openapi';
 import type Submission from 'mssform/models/submission';
@@ -65,6 +66,8 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
   }
 
   @action setUploadVia(val: string) {
+    discardFiles(this.args.state.files);
+
     this.args.model.uploadVia = val;
     this.args.model.extractionId = undefined;
     this.args.state.files = [];
@@ -80,6 +83,8 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
   }
 
   @action removeFile(file: SubmissionFileData) {
+    discardFiles([file]);
+
     this.args.state.files = this.args.state.files.filter((f) => f !== file);
   }
 

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -16,6 +16,7 @@ import MassDirectoryExtractor from 'mssform/components/mass-directory-extractor'
 import RadioGroup from 'mssform/components/radio-group';
 import UploadProgressModal from 'mssform/components/upload-progress-modal';
 import userMassDir from 'mssform/helpers/user-mass-dir';
+import { discardFiles } from 'mssform/models/submission-file';
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
 
 import type { RequestManager } from '@warp-drive/core';
@@ -58,7 +59,15 @@ export default class UploadFormComponent extends Component<Signature> {
     return true;
   }
 
+  willDestroy() {
+    super.willDestroy();
+
+    discardFiles(this.files);
+  }
+
   @action setUploadVia(val: string) {
+    discardFiles(this.files);
+
     this.uploadVia = val;
     this.files.length = 0;
     this.extractionId = null;
@@ -75,6 +84,8 @@ export default class UploadFormComponent extends Component<Signature> {
   }
 
   @action removeFile(file: SubmissionFileData) {
+    discardFiles([file]);
+
     this.files.splice(this.files.indexOf(file), 1);
   }
 

--- a/web/app/models/submission-file.ts
+++ b/web/app/models/submission-file.ts
@@ -62,6 +62,8 @@ export class SubmissionFile implements SubmissionFileData {
   rawFile: File;
   checksum?: Promise<string>;
 
+  #discarded = new AbortController();
+
   constructor(file: File) {
     const { name, type, lastModified } = file;
 
@@ -97,63 +99,89 @@ export class SubmissionFile implements SubmissionFileData {
     return (this.constructor as SubmissionFileSubclass).extensions.find((ext) => this.name.endsWith(ext));
   }
 
+  // Stops the parsing and hashing still running for this file. Hashing a large
+  // file takes a while, and there is nothing left to upload once the file has
+  // been taken off the form.
+  dispose() {
+    this.#discarded.abort();
+  }
+
   parse() {
     this.isParsing = true;
 
-    return new Promise<ParsedData | undefined>((resolve, reject) => {
-      const worker = new Worker((this.constructor as SubmissionFileSubclass).parserURL);
+    return this.#runWorker(
+      (this.constructor as SubmissionFileSubclass).parserURL,
+      ([errs, payload]: [StructuredError[] | string | null, unknown]) => {
+        if (typeof errs === 'string') {
+          console.error(errs);
 
-      worker.addEventListener(
-        'message',
-        ({ data: [errs, payload] }: MessageEvent<[StructuredError[] | string | null, unknown]>) => {
-          if (typeof errs === 'string') {
-            console.error(errs);
+          this.errors.push({ severity: 'error', message: errs });
 
-            this.errors.push({ severity: 'error', message: errs });
+          throw new Error(errs);
+        }
 
-            reject(new Error(errs));
-          } else {
-            if (errs) {
-              this.errors.push(...errs);
-            }
+        if (errs) {
+          this.errors.push(...errs);
+        }
 
-            if (payload) {
-              this.parsedData = payload;
-            }
+        if (payload) {
+          this.parsedData = payload;
+        }
 
-            resolve(this.parsedData);
-          }
-
-          worker.terminate();
-        },
-      );
-
-      worker.postMessage({ file: this.rawFile });
-    }).finally(() => {
+        return this.parsedData;
+      },
+    ).finally(() => {
       this.isParsing = false;
     });
   }
 
   calculateDigest() {
-    this.checksum = new Promise<string>((resolve, reject) => {
-      const worker = new Worker('/workers/calculate-digest.js');
+    this.checksum = this.#runWorker('/workers/calculate-digest.js', ([err, digest]: [string | null, string]) => {
+      if (err) {
+        console.error(err);
 
-      worker.addEventListener('message', ({ data: [err, digest] }: MessageEvent<[string | null, string]>) => {
-        if (err) {
-          console.error(err);
+        throw new Error(err);
+      }
 
-          reject(new Error(err));
-        } else {
-          resolve(digest);
-        }
-
-        worker.terminate();
-      });
-
-      worker.postMessage({ file: this.rawFile });
+      return digest;
     });
 
     return this.checksum;
+  }
+
+  // Hands the file to a worker and settles with its single answer, or with the
+  // `AbortError` the upload also uses if the file is discarded first. The
+  // worker, if one was started at all, is terminated either way.
+  async #runWorker<Message, Result>(url: string, handle: (message: Message) => Result) {
+    const { signal } = this.#discarded;
+
+    signal.throwIfAborted();
+
+    let giveUp!: () => void;
+
+    const message = await new Promise<Message>((resolve, reject) => {
+      const worker = new Worker(url);
+
+      giveUp = () => {
+        worker.terminate();
+
+        reject(signal.reason as Error);
+      };
+
+      signal.addEventListener('abort', giveUp, { once: true });
+
+      worker.addEventListener('message', ({ data }: MessageEvent<Message>) => {
+        worker.terminate();
+
+        resolve(data);
+      });
+
+      worker.postMessage({ file: this.rawFile });
+    }).finally(() => {
+      signal.removeEventListener('abort', giveUp);
+    });
+
+    return handle(message);
   }
 }
 
@@ -187,5 +215,13 @@ export class UnsupportedFile extends SubmissionFile {
     this.isParsing = false;
 
     return Promise.resolve(undefined);
+  }
+}
+
+// Stops whatever is still running for the files being taken off the form.
+// Extracted files are plain data, with no workers of their own.
+export function discardFiles(files: SubmissionFileData[]) {
+  for (const file of files) {
+    if (file instanceof SubmissionFile) file.dispose();
   }
 }

--- a/web/tests/unit/models/submission-file-test.ts
+++ b/web/tests/unit/models/submission-file-test.ts
@@ -3,6 +3,35 @@ import { setupTest } from 'mssform/tests/helpers';
 
 import { SubmissionFile } from 'mssform/models/submission-file';
 
+function isAbortError(error: Error) {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+// Hashing and parsing happen in workers, so watch the terminations at the
+// source. The caller has to `restore()` whatever happens, or the counting
+// subclass outlives the test.
+function watchTerminatedWorkers() {
+  const OriginalWorker = Worker;
+
+  const watcher = {
+    count: 0,
+
+    restore() {
+      window.Worker = OriginalWorker;
+    },
+  };
+
+  window.Worker = class extends OriginalWorker {
+    terminate() {
+      watcher.count += 1;
+
+      super.terminate();
+    }
+  };
+
+  return watcher;
+}
+
 module('Unit | Model | submission file', function (hooks) {
   setupTest(hooks);
 
@@ -28,5 +57,51 @@ module('Unit | Model | submission file', function (hooks) {
         id: 'submission-file.unsupported-filetype',
       },
     ]);
+  });
+
+  test('discarding a file stops the work still running for it', async function (assert) {
+    // A half-done implementation could terminate the worker without settling
+    // the promise: cap the wait rather than riding out QUnit's default timeout.
+    assert.timeout(1000);
+
+    const workers = watchTerminatedWorkers();
+
+    try {
+      const file = SubmissionFile.fromRawFile(new File(['>entry1\nATCG\n'], 'test.fasta'));
+
+      const parsed = file.parse();
+      const checksum = file.calculateDigest();
+
+      file.dispose();
+
+      assert.strictEqual(workers.count, 2, 'the parser and the digest worker are terminated');
+
+      // Whoever is waiting on the file gets the same `AbortError` an abandoned
+      // upload raises, rather than a promise that never settles.
+      await assert.rejects(parsed, isAbortError);
+      await assert.rejects(checksum, isAbortError);
+    } finally {
+      workers.restore();
+    }
+  });
+
+  test('a discarded file starts no further work', async function (assert) {
+    // A half-done implementation could terminate the worker without settling
+    // the promise: cap the wait rather than riding out QUnit's default timeout.
+    assert.timeout(1000);
+
+    const workers = watchTerminatedWorkers();
+
+    try {
+      const file = SubmissionFile.fromRawFile(new File(['>entry1\nATCG\n'], 'test.fasta'));
+
+      file.dispose();
+
+      await assert.rejects(file.calculateDigest(), isAbortError);
+
+      assert.strictEqual(workers.count, 0, 'no worker is started to be terminated');
+    } finally {
+      workers.restore();
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #1625. Parsing and hashing run in Web Workers that nobody stopped. Hashing a large file takes a while, so removing it from the list, switching to an extractor, or walking away from the form all left a worker chewing through a file that will never be uploaded.

A file now carries an `AbortController` of its own. `dispose()` aborts it, which terminates whatever worker is running and settles the promise waiting on it with the same `AbortError` an abandoned upload raises -- `performUpload` already treats that as "nothing to report", and the parse call site already swallows its rejection. Both workers reach that through one helper, since they only differ in which script reads the file and how its single answer is interpreted.

The files outlive the step that collects them, so the submission form discards them when the whole form goes away rather than when the file step is swapped out. Cancelling an upload deliberately does not discard them: the files are still on the form, and the checksum is what the next attempt needs.

## Tests

Two unit tests: discarding a file terminates both workers and rejects what was waiting on them, and a discarded file starts no further work. Both fail against the code they guard. The existing acceptance tests cover the placement of the teardown -- putting it on the file step instead of the form fails four of them, because the checksum is then aborted between step 2 and the upload.

## Worth a look separately

Neither the old nor the new code listens for a worker's `error` event, so a worker script that fails to load leaves the promise unsettled, `isParsing` stuck at `true` (permanent spinner, Next disabled) and the worker never terminated. That is reachable today: `public/workers/calculate-digest.js` pulls its dependency from `cdn.jsdelivr.net`, so a blocked CDN produces exactly that hang. Handling it needs a decision about what the user should see for a file that could not be parsed at all, so it is not bolted on here.