### PR TITLE
Tidy up two leftovers around removing a file

### DIFF
--- a/web/app/components/submission-form.gts
+++ b/web/app/components/submission-form.gts
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { concat } from '@ember/helper';
 import { action } from '@ember/object';
-import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
@@ -15,7 +14,6 @@ import stepNavLinkClass from 'mssform/helpers/step-nav-link-class';
 import { discardFiles } from 'mssform/models/submission-file';
 
 import type { ComponentLike } from '@glint/template';
-import type RouterService from '@ember/routing/router-service';
 import type Submission from 'mssform/models/submission';
 import type { SubmissionFileData } from 'mssform/models/submission-file';
 
@@ -34,8 +32,6 @@ export interface Signature {
 }
 
 export default class SubmissionFormComponent extends Component<Signature> {
-  @service declare router: RouterService;
-
   state = new State();
   nav = new Navigation();
 

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -84,9 +84,13 @@ export default class UploadFormComponent extends Component<Signature> {
   }
 
   @action removeFile(file: SubmissionFileData) {
+    const index = this.files.indexOf(file);
+
+    if (index === -1) return;
+
     discardFiles([file]);
 
-    this.files.splice(this.files.indexOf(file), 1);
+    this.files.splice(index, 1);
   }
 
   @action async submit(uploadProgressModal: UploadProgressModalComponent, event: Event) {


### PR DESCRIPTION
Two small things noticed while reviewing #1626.

`removeFile` in the upload form passed `indexOf`'s answer straight to `splice`, which removes the *last* file when the index is `-1`. The file always comes from the list it is removed from, so it is unreachable today, but the sibling in the submission form uses `filter` and has no such edge. It now bails out instead, and does not dispose a file that was not there to begin with.

The submission form's `router` service has no reader in the class or the template.