### PR TITLE
Show the file when its parser cannot run

### DIFF
--- a/web/app/models/submission-file.ts
+++ b/web/app/models/submission-file.ts
@@ -1,6 +1,8 @@
 import { tracked } from '@glimmer/tracking';
 import { trackedArray } from '@ember/reactive/collections';
 
+import reportError from 'mssform/utils/report-error';
+
 import AnnotationFileParser from '/workers/annotation-file-parser?worker';
 import DigestCalculator from '/workers/calculate-digest?worker';
 import SequenceFileParser from '/workers/sequence-file-parser?worker';
@@ -37,6 +39,10 @@ export interface SubmissionFileData {
 }
 
 type SubmissionFileSubclass = typeof AnnotationFile | typeof SequenceFile | typeof UnsupportedFile;
+
+// The worker could not be run: a failure of the app itself rather than of the
+// file it was handed.
+class WorkerFailure extends Error {}
 
 export class SubmissionFile implements SubmissionFileData {
   static get allowedExtensions() {
@@ -115,6 +121,7 @@ export class SubmissionFile implements SubmissionFileData {
 
     return this.#runWorker(
       (this.constructor as SubmissionFileSubclass).parser,
+      'parser',
       ([errs, payload]: [StructuredError[] | string | null, unknown]) => {
         if (typeof errs === 'string') {
           console.error(errs);
@@ -134,13 +141,24 @@ export class SubmissionFile implements SubmissionFileData {
 
         return this.parsedData;
       },
-    ).finally(() => {
-      this.isParsing = false;
-    });
+    )
+      .catch((error: Error) => {
+        // The parser reports its own errors through `handle`; this is the
+        // worker failing to run at all, which the file has to show as well or
+        // it would look like a file that simply has nothing to say.
+        if (error instanceof WorkerFailure) {
+          this.errors.push({ severity: 'error', id: 'submission-file.parser-failed' });
+        }
+
+        throw error;
+      })
+      .finally(() => {
+        this.isParsing = false;
+      });
   }
 
   calculateDigest() {
-    this.checksum = this.#runWorker(DigestCalculator, ([err, digest]: [string | null, string]) => {
+    this.checksum = this.#runWorker(DigestCalculator, 'digest worker', ([err, digest]: [string | null, string]) => {
       if (err) {
         console.error(err);
 
@@ -156,7 +174,11 @@ export class SubmissionFile implements SubmissionFileData {
   // Hands the file to a worker and settles with its single answer, or with the
   // `AbortError` the upload also uses if the file is discarded first. The
   // worker, if one was started at all, is terminated either way.
-  async #runWorker<Message, Result>(WorkerClass: new () => Worker, handle: (message: Message) => Result) {
+  async #runWorker<Message, Result>(
+    WorkerClass: new () => Worker,
+    label: string,
+    handle: (message: Message) => Result,
+  ) {
     const { signal } = this.#discarded;
 
     signal.throwIfAborted();
@@ -164,7 +186,22 @@ export class SubmissionFile implements SubmissionFileData {
     let giveUp!: () => void;
 
     const message = await new Promise<Message>((resolve, reject) => {
-      const worker = new WorkerClass();
+      const fail = (cause: unknown) => {
+        const failure = new WorkerFailure(`The ${label} could not be run`, { cause });
+
+        reportError(failure);
+        reject(failure);
+      };
+
+      let worker;
+
+      try {
+        worker = new WorkerClass();
+      } catch (error) {
+        fail(error);
+
+        return;
+      }
 
       giveUp = () => {
         worker.terminate();
@@ -173,6 +210,20 @@ export class SubmissionFile implements SubmissionFileData {
       };
 
       signal.addEventListener('abort', giveUp, { once: true });
+
+      // A worker that cannot be started, or that throws before answering,
+      // reports through `error` and never sends a message. A script that fails
+      // to load raises a bare `Event`, so the detail comes from `cause` when
+      // there is any at all.
+      worker.addEventListener('error', (event) => {
+        // Uncancelled, the failure is reported to the page as well, where it
+        // would be an uncaught error rather than this file's problem.
+        event.preventDefault();
+
+        worker.terminate();
+
+        fail(event.error);
+      });
 
       worker.addEventListener('message', ({ data }: MessageEvent<Message>) => {
         worker.terminate();

--- a/web/app/utils/report-error.ts
+++ b/web/app/utils/report-error.ts
@@ -1,0 +1,16 @@
+import { importSync, isTesting, macroCondition } from '@embroider/macros';
+
+// Reports a failure that the app handled itself, so that it still reaches
+// Sentry: only uncaught errors get there on their own.
+export default function reportError(error: Error) {
+  console.error(error);
+
+  if (macroCondition(isTesting())) {
+    // @sentry/ember is not imported in tests, see app.ts.
+    return;
+  }
+
+  const Sentry = importSync('@sentry/ember') as typeof import('@sentry/ember');
+
+  Sentry.captureException(error);
+}

--- a/web/tests/unit/models/submission-file-test.ts
+++ b/web/tests/unit/models/submission-file-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'mssform/tests/helpers';
 
-import { SubmissionFile } from 'mssform/models/submission-file';
+import { SequenceFile, SubmissionFile } from 'mssform/models/submission-file';
 
 function isAbortError(error: Error) {
   return error instanceof DOMException && error.name === 'AbortError';
@@ -32,6 +32,42 @@ function watchTerminatedWorkers() {
   return watcher;
 }
 
+// A file whose parser script is not there to be loaded, which the worker
+// reports as a bare `error` event with nothing to go by.
+class MissingParserFile extends SequenceFile {
+  static parser = class extends Worker {
+    constructor() {
+      super('/workers/no-such-worker.js');
+    }
+  };
+}
+
+// A file whose parser cannot even be constructed.
+class UnstartableParserFile extends SequenceFile {
+  static parser = class extends Worker {
+    constructor() {
+      // The worker has to exist before the constructor can fail, so give it a
+      // script that shuts it down again.
+      super('data:text/javascript,close()');
+
+      throw new Error('the worker could not be created');
+    }
+  };
+}
+
+// A file whose parser starts but throws before it can answer.
+class ThrowingParserFile extends SequenceFile {
+  static parser = class extends Worker {
+    constructor() {
+      const script = URL.createObjectURL(new Blob(['throw new Error("boom")'], { type: 'text/javascript' }));
+
+      super(script);
+
+      URL.revokeObjectURL(script);
+    }
+  };
+}
+
 module('Unit | Model | submission file', function (hooks) {
   setupTest(hooks);
 
@@ -57,6 +93,39 @@ module('Unit | Model | submission file', function (hooks) {
         id: 'submission-file.unsupported-filetype',
       },
     ]);
+  });
+
+  test('a parser that cannot be loaded is shown on the file', async function (assert) {
+    // Nothing settles the promise if the failure goes unnoticed.
+    assert.timeout(2000);
+
+    const file = new MissingParserFile(new File(['>entry1\nATCG\n'], 'test.fasta'));
+
+    await assert.rejects(file.parse());
+
+    assert.deepEqual(file.errors, [{ severity: 'error', id: 'submission-file.parser-failed' }]);
+    assert.false(file.isParsing, 'the spinner stops');
+    assert.false(file.isParseSucceeded, 'the file cannot be submitted');
+  });
+
+  test('a parser that cannot be constructed is shown on the file', async function (assert) {
+    assert.timeout(2000);
+
+    const file = new UnstartableParserFile(new File(['>entry1\nATCG\n'], 'test.fasta'));
+
+    await assert.rejects(file.parse());
+
+    assert.deepEqual(file.errors, [{ severity: 'error', id: 'submission-file.parser-failed' }]);
+  });
+
+  test('a parser that throws is shown on the file', async function (assert) {
+    assert.timeout(2000);
+
+    const file = new ThrowingParserFile(new File(['>entry1\nATCG\n'], 'test.fasta'));
+
+    await assert.rejects(file.parse());
+
+    assert.deepEqual(file.errors, [{ severity: 'error', id: 'submission-file.parser-failed' }]);
   });
 
   test('discarding a file stops the work still running for it', async function (assert) {

--- a/web/translations/en.yaml
+++ b/web/translations/en.yaml
@@ -247,6 +247,7 @@ upload-progress-modal:
 submission-file:
   invalid-filename: 'Filename must be alphanumeric characters and the following symbols are not allowed: \/:*?"<>|.'
   unsupported-filetype: Unsupported file type.
+  parser-failed: This file could not be checked because the page did not load properly. Please reload the page and try again.
 
 annotation-file-parser:
   invalid-hold-date: hold_date must be an 8-digit number (YYYYMMDD).

--- a/web/translations/ja.yaml
+++ b/web/translations/ja.yaml
@@ -248,6 +248,7 @@ upload-progress-modal:
 submission-file:
   invalid-filename: 'ファイル名は半角英数字にしてください。また、次の記号は使えません: \/:*?"<>|.'
   unsupported-filetype: 対応していないファイル形式です。
+  parser-failed: ページの読み込みに問題があり、このファイルを確認できませんでした。ページを再読み込みしてください。
 
 annotation-file-parser:
   invalid-hold-date: hold_date は8桁の数字 (YYYYMMDD) で指定してください。


### PR DESCRIPTION
The other half of the note on #1626, now that #1628 has removed the CDN that made it reachable.

A worker only reports through `message` and `error`, and nobody listened for `error`. A worker that could not be started, or that threw before answering, therefore left `parse` pending for good: the file kept its spinner, `isParsing` stayed `true`, and the file step could never be left. The failure also reached the page as an uncaught error, where it read as a bug in the app rather than as a file that could not be read.

`#runWorker` now cancels that event and rejects with it, and `parse` records it on the file the way the parser's own errors are recorded, so the file shows what happened and cannot be submitted. The message points at the page rather than the file: a worker that will not run fails every file at once, and a reload is what fixes it.

## Two things that fell out of it

The digest worker gets the same treatment, which turns another hang into an answer. The upload used to sit at "Calculating hash..." forever when the digest worker could not run; it now reports through the error modal like any other upload failure.

Cancelling the `error` event keeps the failure out of Sentry — `globalHandlersIntegration` is what used to catch it — so it is reported explicitly instead. `report-error` keeps the same "not in tests" shape the Sentry setup in `app.ts` already uses.

## Tests

Four unit tests, one per shape a worker can fail in: a script that is not there (a bare `error` event with no message, which is what a missing chunk actually looks like), a worker that throws after starting, a constructor that fails, and the existing digest check. Each fails against the code it guards.