### PR TITLE
Give the upload form the validation it meant to have

### DIFF
--- a/web/app/components/submission-form/files.gts
+++ b/web/app/components/submission-form/files.gts
@@ -15,12 +15,19 @@ import userMassDir from 'mssform/helpers/user-mass-dir';
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
 import OtherPerson from 'mssform/models/other-person';
 import { discardFiles } from 'mssform/models/submission-file';
+import {
+  collectCrossoverErrors,
+  hasBlockingErrors,
+  validateDuplicates,
+  validatePairs,
+  validateSameness,
+} from 'mssform/utils/crossover-errors';
 
 import type { paths } from 'schema/openapi';
 import type Submission from 'mssform/models/submission';
 import type { Navigation, State } from 'mssform/components/submission-form';
 import type { RequestManager } from '@warp-drive/core';
-import type { SubmissionFileData, SubmissionError, ParsedData } from 'mssform/models/submission-file';
+import type { SubmissionFileData } from 'mssform/models/submission-file';
 
 export interface Signature {
   Args: {
@@ -33,18 +40,10 @@ export interface Signature {
 export default class SubmissionFormFilesComponent extends Component<Signature> {
   @service declare requestManager: RequestManager;
 
+  // A new submission has to arrive complete: whole pairs, agreeing with each
+  // other.
   get crossoverErrors() {
-    const { files } = this.args.state;
-    const errors = new Map<SubmissionFileData, SubmissionError[]>();
-
-    for (const file of files) {
-      errors.set(file, []);
-    }
-
-    validatePair(errors, files);
-    validateSameness(errors, files);
-
-    return errors;
+    return collectCrossoverErrors(this.args.state.files, [validateDuplicates, validatePairs, validateSameness]);
   }
 
   get isNextButtonEnabled() {
@@ -54,15 +53,7 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
     if (!uploadVia) return false;
     if (!files.length) return false;
 
-    for (const file of files) {
-      if (file.isParsing || file.errors?.some((e) => e.severity === 'error')) return false;
-    }
-
-    for (const errs of this.crossoverErrors.values()) {
-      if (errs.some((e) => e.severity === 'error')) return false;
-    }
-
-    return true;
+    return !hasBlockingErrors(files, this.crossoverErrors);
   }
 
   @action setUploadVia(val: string) {
@@ -289,94 +280,4 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
       </div>
     </form>
   </template>
-}
-
-function validatePair(errors: Map<SubmissionFileData, SubmissionError[]>, files: SubmissionFileData[]) {
-  const grouped = files.reduce((map, file) => {
-    const val = map.has(file.basename) ? [...map.get(file.basename)!, file] : [file];
-
-    return map.set(file.basename, val);
-  }, new Map<string, SubmissionFileData[]>());
-
-  for (const files of grouped.values()) {
-    const [annotations, sequences] = files.reduce(
-      ([ann, seq], file) => {
-        return [
-          file.fileType === 'annotation' ? [...ann, file] : ann,
-          file.fileType === 'sequence' ? [...seq, file] : seq,
-        ];
-      },
-      [[], []] as [SubmissionFileData[], SubmissionFileData[]],
-    );
-
-    if (!annotations.length) {
-      for (const file of sequences) {
-        errors.get(file)!.push({
-          severity: 'error',
-          id: 'submission-form.files.errors.no-annotation',
-        });
-      }
-    }
-
-    if (annotations.length > 1) {
-      for (const file of annotations) {
-        errors.get(file)!.push({
-          severity: 'error',
-          id: 'submission-form.files.errors.duplicate-annotations',
-        });
-      }
-    }
-
-    if (!sequences.length) {
-      for (const file of annotations) {
-        errors.get(file)!.push({
-          severity: 'error',
-          id: 'submission-form.files.errors.no-sequence',
-        });
-      }
-    }
-
-    if (sequences.length > 1) {
-      for (const file of sequences) {
-        errors.get(file)!.push({
-          severity: 'error',
-          id: 'submission-form.files.errors.duplicate-sequences',
-        });
-      }
-    }
-  }
-}
-
-function validateSameness(errors: Map<SubmissionFileData, SubmissionError[]>, files: SubmissionFileData[]) {
-  const filtered = files.filter((file) => file.fileType === 'annotation' && file.isParseSucceeded);
-
-  if (!filtered.length) return;
-
-  const contactPersonSet = new Set<string>();
-  const holdDateSet = new Set<string>();
-
-  for (const file of filtered) {
-    const { contactPerson, holdDate } = file.parsedData as ParsedData;
-
-    contactPersonSet.add(JSON.stringify(contactPerson));
-    holdDateSet.add(holdDate ?? '');
-  }
-
-  if (contactPersonSet.size > 1) {
-    for (const file of filtered) {
-      errors.get(file)!.push({
-        severity: 'error',
-        id: 'submission-form.files.errors.different-contact-person',
-      });
-    }
-  }
-
-  if (holdDateSet.size > 1) {
-    for (const file of filtered) {
-      errors.get(file)!.push({
-        severity: 'error',
-        id: 'submission-form.files.errors.different-hold-date',
-      });
-    }
-  }
 }

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -17,10 +17,16 @@ import RadioGroup from 'mssform/components/radio-group';
 import UploadProgressModal from 'mssform/components/upload-progress-modal';
 import userMassDir from 'mssform/helpers/user-mass-dir';
 import { discardFiles } from 'mssform/models/submission-file';
+import {
+  collectCrossoverErrors,
+  hasBlockingErrors,
+  validateDuplicates,
+  validateSameness,
+} from 'mssform/utils/crossover-errors';
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
 
 import type { RequestManager } from '@warp-drive/core';
-import type { SubmissionFile, SubmissionFileData, SubmissionError } from 'mssform/models/submission-file';
+import type { SubmissionFile, SubmissionFileData } from 'mssform/models/submission-file';
 import type UploadProgressModalComponent from 'mssform/components/upload-progress-modal';
 
 interface DirectUploadBlob {
@@ -44,7 +50,15 @@ export default class UploadFormComponent extends Component<Signature> {
   @tracked extractionId: number | null = null;
   files: SubmissionFileData[] = trackedArray();
   @tracked isCompleted = false;
-  @tracked crossoverErrors = new Map<SubmissionFileData, SubmissionError[]>();
+
+  // Re-uploading often means replacing one half of a pair, so a lone annotation
+  // or sequence file is expected here -- unlike in the submission form, which
+  // takes whole pairs only. The rest still holds: the same name twice is a
+  // mistake, and the annotation files sent together have to agree on the
+  // contact person and the hold date the submission already has.
+  get crossoverErrors() {
+    return collectCrossoverErrors(this.files, [validateDuplicates, validateSameness]);
+  }
 
   get isSubmitButtonEnabled() {
     const { uploadVia, files } = this;
@@ -52,11 +66,7 @@ export default class UploadFormComponent extends Component<Signature> {
     if (!uploadVia) return false;
     if (!files.length) return false;
 
-    for (const file of files) {
-      if (file.isParsing || file.errors?.length) return false;
-    }
-
-    return true;
+    return !hasBlockingErrors(files, this.crossoverErrors);
   }
 
   willDestroy() {

--- a/web/app/utils/crossover-errors.ts
+++ b/web/app/utils/crossover-errors.ts
@@ -1,0 +1,107 @@
+import type { SubmissionError, SubmissionFileData } from 'mssform/models/submission-file';
+
+export type CrossoverErrors = Map<SubmissionFileData, SubmissionError[]>;
+
+type Validation = (errors: CrossoverErrors, files: SubmissionFileData[]) => void;
+
+// Errors a file only has in the company of the others being sent with it, as
+// opposed to the ones its parser found in it on its own. Which of them apply
+// is up to the form: they are not the same for a new submission and for files
+// added to an existing one.
+export function collectCrossoverErrors(files: SubmissionFileData[], validations: Validation[]) {
+  const errors: CrossoverErrors = new Map(files.map((file) => [file, []]));
+
+  for (const validate of validations) {
+    validate(errors, files);
+  }
+
+  return errors;
+}
+
+// Whether anything stands in the way of sending these files.
+export function hasBlockingErrors(files: SubmissionFileData[], crossoverErrors: CrossoverErrors) {
+  for (const file of files) {
+    if (file.isParsing) return true;
+    if (file.errors?.some((e) => e.severity === 'error')) return true;
+  }
+
+  for (const errors of crossoverErrors.values()) {
+    if (errors.some((e) => e.severity === 'error')) return true;
+  }
+
+  return false;
+}
+
+// Two files of the same kind claiming the same name, whatever the form.
+export function validateDuplicates(errors: CrossoverErrors, files: SubmissionFileData[]) {
+  for (const [annotations, sequences] of groupByBasename(files)) {
+    if (annotations.length > 1) {
+      mark(errors, annotations, 'submission-form.files.errors.duplicate-annotations');
+    }
+
+    if (sequences.length > 1) {
+      mark(errors, sequences, 'submission-form.files.errors.duplicate-sequences');
+    }
+  }
+}
+
+// Every annotation file needs its sequence file and the other way round.
+export function validatePairs(errors: CrossoverErrors, files: SubmissionFileData[]) {
+  for (const [annotations, sequences] of groupByBasename(files)) {
+    if (!annotations.length) {
+      mark(errors, sequences, 'submission-form.files.errors.no-annotation');
+    }
+
+    if (!sequences.length) {
+      mark(errors, annotations, 'submission-form.files.errors.no-sequence');
+    }
+  }
+}
+
+// One submission carries one contact person and one hold date, so the
+// annotation files have to agree on them.
+export function validateSameness(errors: CrossoverErrors, files: SubmissionFileData[]) {
+  const annotations = files.filter((file) => file.fileType === 'annotation' && file.parsedData);
+
+  if (!annotations.length) return;
+
+  const contactPersons = new Set<string>();
+  const holdDates = new Set<string>();
+
+  for (const { parsedData } of annotations) {
+    const { contactPerson, holdDate } = parsedData!;
+
+    contactPersons.add(JSON.stringify(contactPerson));
+    holdDates.add(holdDate ?? '');
+  }
+
+  if (contactPersons.size > 1) {
+    mark(errors, annotations, 'submission-form.files.errors.different-contact-person');
+  }
+
+  if (holdDates.size > 1) {
+    mark(errors, annotations, 'submission-form.files.errors.different-hold-date');
+  }
+}
+
+// The files that share a name, split into the two halves of a pair.
+function groupByBasename(files: SubmissionFileData[]) {
+  const groups = new Map<string, [SubmissionFileData[], SubmissionFileData[]]>();
+
+  for (const file of files) {
+    const [annotations, sequences] = groups.get(file.basename) ?? [[], []];
+
+    if (file.fileType === 'annotation') annotations.push(file);
+    if (file.fileType === 'sequence') sequences.push(file);
+
+    groups.set(file.basename, [annotations, sequences]);
+  }
+
+  return groups.values();
+}
+
+function mark(errors: CrossoverErrors, files: SubmissionFileData[], id: string) {
+  for (const file of files) {
+    errors.get(file)!.push({ severity: 'error', id });
+  }
+}

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -12,6 +12,7 @@ import {
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'mssform/tests/helpers';
 import { setupAuthentication } from 'mssform/tests/helpers/setup-auth';
+import clickRadio from 'mssform/tests/helpers/click-radio';
 
 import { HttpResponse, http as mswHttp } from 'msw';
 import ENV from 'mssform/config/environment';
@@ -24,18 +25,6 @@ import { worker } from '../msw/worker';
 // Bootstrap modals that a previous test leaked into `<body>`: Bootstrap
 // re-appends a modal there if its show transition is still pending when the
 // application is torn down.
-function clickRadio(labelText: string) {
-  const labels = findAll('.form-check-label') as HTMLLabelElement[];
-  const label = labels.find((el) => el.textContent?.trim().startsWith(labelText));
-
-  if (!label) throw new Error(`Radio label not found: "${labelText}"`);
-
-  const input = label.control as HTMLInputElement | null;
-
-  if (!input) throw new Error(`Radio input not found for label: "${labelText}"`);
-
-  return click(input);
-}
 
 // Walks a webui upload from the home page to the confirm step, with the terms
 // agreed to, leaving the caller to submit the application.

--- a/web/tests/acceptance/upload-test.gts
+++ b/web/tests/acceptance/upload-test.gts
@@ -1,0 +1,122 @@
+import { module, test } from 'qunit';
+import { visit, click, findAll, getRootElement, triggerEvent, waitUntil } from '@ember/test-helpers';
+import { setupApplicationTest } from 'mssform/tests/helpers';
+import { setupAuthentication } from 'mssform/tests/helpers/setup-auth';
+import clickRadio from 'mssform/tests/helpers/click-radio';
+
+import { HttpResponse } from 'msw';
+import { http } from '../msw/http';
+import { worker } from '../msw/worker';
+
+function annotationFile(name = 'test.ann', contact = 'Alice Liddell') {
+  const lines = [
+    `COMMON\tSUBMITTER\t\tcontact\t${contact}\n`,
+    '\t\t\temail\talice@example.com\n',
+    '\t\t\tinstitute\tWonderland Inc.\n',
+    'CLN01\tgene\t1..100\tlocus_tag\tLOCUS_0001\n',
+  ];
+
+  return new File([lines.join('')], name);
+}
+
+function sequenceFile(name = 'test.fasta') {
+  return new File(['>entry1\nATCG\n'], name);
+}
+
+// Files land on the form parsed and hashed; nothing is submitted until they are.
+async function addFiles(files: File[]) {
+  await triggerEvent('input[type="file"]', 'change', { files });
+
+  await waitUntil(() => findAll('.spinner-border').length === 0);
+}
+
+module('Acceptance | upload', function (hooks) {
+  setupApplicationTest(hooks);
+  setupAuthentication(hooks);
+
+  hooks.beforeEach(function () {
+    worker.use(
+      http.get('/submissions/{mass_id}', ({ response }) => {
+        return response(200).json({
+          submission: {
+            id: 'NSUB000001',
+            created_at: '2026-08-14T00:00:00Z',
+            status: null,
+            accessions: [],
+            uploads: [],
+          },
+        });
+      }),
+    );
+  });
+
+  test('adding the half of a pair that changed', async function (assert) {
+    let uploaded: unknown;
+
+    worker.use(
+      http.post('/submissions/{mass_id}/uploads', async ({ request }) => {
+        uploaded = await request.json();
+
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await visit('/home/submission/NSUB000001/upload');
+
+    await clickRadio('Upload the submission files through the MSS form');
+
+    // Re-uploading a sequence file on its own is the point of this form: the
+    // annotation file it belongs to was submitted before.
+    await addFiles([sequenceFile()]);
+
+    assert.dom('button.px-5[type="submit"]').isNotDisabled('a file without its pair can be sent');
+
+    await click('button.px-5[type="submit"]');
+
+    await waitUntil(() => getRootElement().textContent?.includes('Go to home'));
+
+    assert.deepEqual(uploaded, { upload: { via: 'webui', files: ['test-signed-id'] } });
+  });
+
+  test('a warning does not stand in the way', async function (assert) {
+    await visit('/home/submission/NSUB000001/upload');
+
+    await clickRadio('Upload the submission files through the MSS form');
+
+    // The annotation file carries a temporary locus_tag, which is reported as
+    // a warning and cannot be acted on: it must not block the upload.
+    await addFiles([annotationFile(), sequenceFile()]);
+
+    assert.dom('.list-group-item').exists({ count: 2 });
+    assert.dom('.list-group-item').containsText('LOCUS_0001', 'the warning is shown');
+    assert.dom('button.px-5[type="submit"]').isNotDisabled();
+  });
+
+  test('the annotation files disagree with each other', async function (assert) {
+    await visit('/home/submission/NSUB000001/upload');
+
+    await clickRadio('Upload the submission files through the MSS form');
+
+    // The submission has one contact person, so annotation files sent together
+    // cannot name two -- there is nowhere else this would be caught.
+    await addFiles([annotationFile('foo.ann'), annotationFile('bar.ann', 'Bob Carroll')]);
+
+    assert.dom('.list-group-item').containsText('are not the same');
+    assert.dom('button.px-5[type="submit"]').isDisabled();
+  });
+
+  test('the same file twice', async function (assert) {
+    await visit('/home/submission/NSUB000001/upload');
+
+    await clickRadio('Upload the submission files through the MSS form');
+
+    await addFiles([sequenceFile(), sequenceFile()]);
+
+    for (const item of findAll('.list-group-item')) {
+      assert.dom(item).containsText('Duplicate sequence files with the same name exist.');
+    }
+
+    assert.dom('.list-group-item').exists({ count: 2 }, 'both files are flagged');
+    assert.dom('button.px-5[type="submit"]').isDisabled();
+  });
+});

--- a/web/tests/helpers/click-radio.ts
+++ b/web/tests/helpers/click-radio.ts
@@ -1,0 +1,16 @@
+import { click, findAll } from '@ember/test-helpers';
+
+// Radios are labelled by their translation and carry generated ids, so they are
+// found by the text next to them.
+export default function clickRadio(labelText: string) {
+  const labels = findAll('.form-check-label') as HTMLLabelElement[];
+  const label = labels.find((el) => el.textContent?.trim().startsWith(labelText));
+
+  if (!label) throw new Error(`Radio label not found: "${labelText}"`);
+
+  const input = label.control as HTMLInputElement | null;
+
+  if (!input) throw new Error(`Radio input not found for label: "${labelText}"`);
+
+  return click(input);
+}

--- a/web/tests/unit/utils/crossover-errors-test.ts
+++ b/web/tests/unit/utils/crossover-errors-test.ts
@@ -1,0 +1,125 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'mssform/tests/helpers';
+
+import {
+  collectCrossoverErrors,
+  hasBlockingErrors,
+  validateDuplicates,
+  validatePairs,
+  validateSameness,
+} from 'mssform/utils/crossover-errors';
+
+import type { SubmissionFileData, SubmissionError } from 'mssform/models/submission-file';
+
+interface FileOptions {
+  parsedData?: SubmissionFileData['parsedData'];
+  errors?: SubmissionError[];
+  isParsing?: boolean;
+}
+
+function file(name: string, fileType: 'annotation' | 'sequence', options: FileOptions = {}): SubmissionFileData {
+  const { parsedData, errors = [], isParsing = false } = options;
+
+  return {
+    name,
+    basename: name,
+    size: 1,
+    fileType,
+    isParsing,
+    parsedData,
+    isParseSucceeded: Boolean(parsedData),
+    errors,
+  };
+}
+
+function contactPerson(email: string) {
+  return { email, fullName: 'Alice Liddell', affiliation: 'Wonderland Inc.' };
+}
+
+function idsFor(errors: Map<SubmissionFileData, SubmissionError[]>, target: SubmissionFileData) {
+  return errors.get(target)!.map((error) => error.id);
+}
+
+module('Unit | Utility | crossover errors', function (hooks) {
+  setupTest(hooks);
+
+  test('a pair is complete', function (assert) {
+    const annotation = file('foo', 'annotation');
+    const sequence = file('foo', 'sequence');
+    const files = [annotation, sequence];
+
+    const errors = collectCrossoverErrors(files, [validateDuplicates, validatePairs]);
+
+    assert.deepEqual(idsFor(errors, annotation), []);
+    assert.deepEqual(idsFor(errors, sequence), []);
+  });
+
+  test('a half of a pair is missing', function (assert) {
+    const annotation = file('foo', 'annotation');
+    const orphan = file('bar', 'sequence');
+    const files = [annotation, file('foo', 'sequence'), orphan];
+
+    const errors = collectCrossoverErrors(files, [validatePairs]);
+
+    assert.deepEqual(idsFor(errors, orphan), ['submission-form.files.errors.no-annotation']);
+    assert.deepEqual(idsFor(errors, annotation), [], 'the complete pair is left alone');
+  });
+
+  test('a half of a pair is missing, where that is allowed', function (assert) {
+    const orphan = file('bar', 'sequence');
+
+    // What a re-upload replacing one half of a pair looks like.
+    const errors = collectCrossoverErrors([orphan], [validateDuplicates]);
+
+    assert.deepEqual(idsFor(errors, orphan), []);
+  });
+
+  test('the same file twice', function (assert) {
+    const first = file('foo', 'annotation');
+    const second = file('foo', 'annotation');
+
+    const errors = collectCrossoverErrors([first, second], [validateDuplicates]);
+
+    assert.deepEqual(idsFor(errors, first), ['submission-form.files.errors.duplicate-annotations']);
+    assert.deepEqual(idsFor(errors, second), ['submission-form.files.errors.duplicate-annotations']);
+  });
+
+  test('the annotation files disagree', function (assert) {
+    const alice = file('foo', 'annotation', {
+      parsedData: { contactPerson: contactPerson('alice@example.com'), holdDate: '2020-01-02' },
+    });
+
+    const bob = file('bar', 'annotation', {
+      parsedData: { contactPerson: contactPerson('bob@example.com'), holdDate: '2030-04-05' },
+    });
+
+    const errors = collectCrossoverErrors([alice, bob], [validateSameness]);
+
+    assert.deepEqual(idsFor(errors, alice), [
+      'submission-form.files.errors.different-contact-person',
+      'submission-form.files.errors.different-hold-date',
+    ]);
+  });
+
+  test('files that are still being read block', function (assert) {
+    const files = [file('foo', 'annotation', { isParsing: true })];
+
+    assert.true(hasBlockingErrors(files, collectCrossoverErrors(files, [])));
+  });
+
+  test('a warning does not block', function (assert) {
+    const files = [file('foo', 'annotation', { errors: [{ severity: 'warning', id: 'whatever' }] })];
+
+    assert.false(hasBlockingErrors(files, collectCrossoverErrors(files, [])));
+  });
+
+  test('an error blocks, wherever it comes from', function (assert) {
+    const withOwnError = [file('foo', 'annotation', { errors: [{ severity: 'error', id: 'whatever' }] })];
+
+    assert.true(hasBlockingErrors(withOwnError, collectCrossoverErrors(withOwnError, [])));
+
+    const duplicated = [file('foo', 'annotation'), file('foo', 'annotation')];
+
+    assert.true(hasBlockingErrors(duplicated, collectCrossoverErrors(duplicated, [validateDuplicates])));
+  });
+});


### PR DESCRIPTION
Found while looking at the duplication between the two forms that collect submission files. They had grown apart in two ways, both in `upload-form.gts`:

- `crossoverErrors` was a `@tracked` empty `Map` that nothing ever wrote to, so **nothing compared the files with each other** — only the submission form's getter filled it. Nothing on the backend does either: `Submissions::UploadsController#create` never reads the files.
- The submit button turned itself off on `errors.length`, warnings included. The annotation parser reports a temporary `locus_tag` as a `warning` — a notice the submitter cannot act on — so such a file **left the form with no way forward**. The submission form uses `severity === 'error'`.

## What each form validates now

The checks move to `utils/crossover-errors.ts` and each form states which apply to it:

| | duplicates | pairs | sameness |
|---|---|---|---|
| new submission | ✓ | ✓ | ✓ |
| re-upload | ✓ | | ✓ |

A re-upload often replaces just **one half of a pair**, so requiring complete pairs there would break a real workflow; a lone annotation or sequence file has to keep going through. The rest still applies: the same name twice is a mistake either way, and annotation files sent together have to agree on the contact person and hold date the submission already has — nothing else would catch that. `pairs` and `duplicates` split out of the old `validatePair` for that reason. Deciding what blocks a submission moves to the same place, which is what let the two forms disagree about warnings.

This widens the upload form's extractor paths as a side effect: dfast, ggs and mass directory imports were covered by the same empty map and now answer for duplicate names and disagreeing annotation files, as they already do in the submission form.

## Tests

The upload route had none at all. The four it gets state the policy — one half of a pair goes through, a warning goes through, the same file twice does not, annotation files naming two contact persons do not — and each fails against the code it guards. Adding the pair check to this form fails the first of them, which is the point. The wizard's behaviour is unchanged: the split validators were checked against the old ones over every combination of two basenames × three file types × three parse states.

## Not done

The remaining duplication is the UI itself: ~95 lines of near-identical template (the method radios and the extractor/file-list branches) and the state actions. Extracting it needs the shared piece to *take* the state rather than own it, because the wizard's files outlive the step component. Left for a separate change.