### PR TITLE
Let both forms share how files are chosen

### DIFF
--- a/web/app/components/file-chooser.gts
+++ b/web/app/components/file-chooser.gts
@@ -1,0 +1,148 @@
+import { t } from 'ember-intl';
+import svgJar from 'ember-svg-jar/helpers/svg-jar';
+
+import FileList from 'mssform/components/file-list';
+import JobIdExtractor from 'mssform/components/job-id-extractor';
+import SupportedFileTypes from 'mssform/components/file-list/supported-file-types';
+import MassDirectoryExtractor from 'mssform/components/mass-directory-extractor';
+import RadioGroup from 'mssform/components/radio-group';
+import userMassDir from 'mssform/helpers/user-mass-dir';
+
+import type { TOC } from '@ember/component/template-only';
+import type FileSelection from 'mssform/models/file-selection';
+
+interface Signature {
+  Args: {
+    selection: FileSelection;
+  };
+
+  Blocks: {
+    // Shown above the choices, where the form has something to say about them.
+    question?: [];
+
+    // Shown above the file list, which the two forms introduce differently.
+    instructions?: [];
+  };
+}
+
+// How a form's files are chosen: an extraction to import them from, or the
+// files themselves. Both forms that collect files use this; what they do with
+// the selection afterwards is their own.
+<template>
+  <div class="vstack gap-3">
+    <div class="card">
+      <div class="card-body">
+        {{yield to="question"}}
+
+        <RadioGroup as |group|>
+          <div class="form-check">
+            <group.radio as |radio|>
+              <radio.input
+                checked={{eq @selection.via "dfast"}}
+                required
+                class="form-check-input"
+                {{on "change" (fn @selection.setVia "dfast")}}
+              />
+
+              <radio.label class="form-check-label">
+                {{t "submission-form.files.a1"}}
+              </radio.label>
+            </group.radio>
+          </div>
+
+          <div class="form-check">
+            <group.radio as |radio|>
+              <radio.input
+                checked={{eq @selection.via "ggs"}}
+                required
+                class="form-check-input"
+                {{on "change" (fn @selection.setVia "ggs")}}
+              />
+
+              <radio.label class="form-check-label">
+                {{t "submission-form.files.a4"}}
+              </radio.label>
+            </group.radio>
+          </div>
+
+          <div class="form-check">
+            <group.radio as |radio|>
+              <radio.input
+                checked={{eq @selection.via "webui"}}
+                required
+                class="form-check-input"
+                {{on "change" (fn @selection.setVia "webui")}}
+              />
+
+              <radio.label class="form-check-label">
+                {{t "submission-form.files.a2"}}
+              </radio.label>
+            </group.radio>
+          </div>
+
+          <div class="hstack gap-3">
+            <div class="form-check">
+              <group.radio as |radio|>
+                <radio.input
+                  checked={{eq @selection.via "mass_directory"}}
+                  required
+                  class="form-check-input"
+                  {{on "change" (fn @selection.setVia "mass_directory")}}
+                />
+
+                <radio.label class="form-check-label">
+                  {{t "submission-form.files.a3-html" htmlSafe=true userMassDir=(userMassDir)}}
+                </radio.label>
+
+                {{t "submission-form.files.a3-note-html" htmlSafe=true}}
+              </group.radio>
+            </div>
+
+            <small>
+              <a href={{t "submission-form.files.a3-help-url"}} target="_blank" rel="noopener noreferrer">
+                {{svgJar "question-16" class="octicon" width="14px" style="margin-top: 2px"}}
+                {{t "submission-form.files.a3-help-text"}}
+              </a>
+            </small>
+          </div>
+        </RadioGroup>
+      </div>
+    </div>
+
+    {{#if (eq @selection.via "dfast")}}
+      <JobIdExtractor
+        @endpoint="/dfast_extractions"
+        @i18nPrefix="dfast-extractor"
+        @onPoll={{@selection.onExtractProgress}}
+        @crossoverErrors={{@selection.crossoverErrors}}
+      />
+    {{else if (eq @selection.via "ggs")}}
+      <JobIdExtractor
+        @endpoint="/ggs_extractions"
+        @i18nPrefix="ggs-extractor"
+        @onPoll={{@selection.onExtractProgress}}
+        @crossoverErrors={{@selection.crossoverErrors}}
+      />
+    {{else if (eq @selection.via "webui")}}
+      <div class="card">
+        <div class="card-body">
+          {{yield to="instructions"}}
+
+          <SupportedFileTypes />
+
+          <FileList
+            @files={{@selection.files}}
+            @crossoverErrors={{@selection.crossoverErrors}}
+            @onAdd={{@selection.addFile}}
+            @onRemove={{@selection.removeFile}}
+          />
+        </div>
+      </div>
+    {{else if (eq @selection.via "mass_directory")}}
+      <MassDirectoryExtractor
+        @onPoll={{@selection.onExtractProgress}}
+        @crossoverErrors={{@selection.crossoverErrors}}
+      />
+    {{/if}}
+  </div>
+</template> satisfies TOC<Signature>;

--- a/web/app/components/submission-form.gts
+++ b/web/app/components/submission-form.gts
@@ -11,11 +11,11 @@ import Files from './submission-form/files';
 import Metadata from './submission-form/metadata';
 import Prerequisite from './submission-form/prerequisite';
 import stepNavLinkClass from 'mssform/helpers/step-nav-link-class';
-import { discardFiles } from 'mssform/models/submission-file';
+import FileSelection from 'mssform/models/file-selection';
+import { validateDuplicates, validatePairs, validateSameness } from 'mssform/utils/crossover-errors';
 
 import type { ComponentLike } from '@glint/template';
 import type Submission from 'mssform/models/submission';
-import type { SubmissionFileData } from 'mssform/models/submission-file';
 
 const COMPONENTS: Record<string, unknown> = {
   prerequisite: Prerequisite,
@@ -38,9 +38,9 @@ export default class SubmissionFormComponent extends Component<Signature> {
   willDestroy() {
     super.willDestroy();
 
-    // The files outlive the step that collected them, so they are discarded
-    // here rather than when the file step is swapped out.
-    discardFiles(this.state.files);
+    // The selection outlives the step that made it, so it is discarded here
+    // rather than when the file step is swapped out.
+    this.state.selection.discard();
   }
 
   get component() {
@@ -92,7 +92,10 @@ export default class SubmissionFormComponent extends Component<Signature> {
 export class State {
   @tracked maybeTpa: boolean | null = null;
   @tracked agreed = false;
-  @tracked files: SubmissionFileData[] = [];
+
+  // A new submission has to arrive complete: whole pairs, agreeing with each
+  // other.
+  selection = new FileSelection([validateDuplicates, validatePairs, validateSameness]);
 }
 
 export class Navigation {

--- a/web/app/components/submission-form/confirm.gts
+++ b/web/app/components/submission-form/confirm.gts
@@ -38,10 +38,10 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
   @action async submit(uploadProgressModal: UploadProgressModalComponent, event: Event) {
     event.preventDefault();
     const { state, model, nav } = this.args;
-    const { uploadVia } = model;
+    const { selection } = state;
 
-    if (uploadVia === 'webui') {
-      const blobs = (await uploadProgressModal.performUpload(state.files as SubmissionFile[])) as unknown as
+    if (selection.via === 'webui') {
+      const blobs = (await uploadProgressModal.performUpload(selection.files as SubmissionFile[])) as unknown as
         DirectUploadBlob[] | undefined;
 
       // The upload failed and was surfaced in the error modal, or it was
@@ -60,9 +60,9 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
       data: {
         submission: {
           tpa: model.tpa,
-          upload_via: model.uploadVia,
+          upload_via: selection.via,
           files: model.files,
-          extraction_id: model.extractionId,
+          extraction_id: selection.extractionId,
           entries_count: model.entriesCount,
           hold_date: model.holdDate,
           sequencer: model.sequencer,
@@ -114,23 +114,23 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
                   <li>{{t "submission-form.prerequisite.a1-1"}}</li>
                 {{/if}}
 
-                {{#if (eq @model.uploadVia "dfast")}}
+                {{#if (eq @state.selection.via "dfast")}}
                   <li>{{t "submission-form.files.a1"}}</li>
-                {{else if (eq @model.uploadVia "webui")}}
+                {{else if (eq @state.selection.via "webui")}}
                   <li>{{t "submission-form.files.a2"}}</li>
-                {{else if (eq @model.uploadVia "mass_directory")}}
+                {{else if (eq @state.selection.via "mass_directory")}}
                   <li>{{t "submission-form.files.a3-html" htmlSafe=true userMassDir=(userMassDir)}}</li>
                 {{/if}}
               </ul>
             </div>
           </div>
 
-          {{#if @state.files}}
+          {{#if @state.selection.files}}
             <div class="card">
               <div class="card-header">{{t "submission-form.confirm.files"}}</div>
 
               <ul class="list-group list-group-flush">
-                {{#each @state.files as |file|}}
+                {{#each @state.selection.files as |file|}}
                   <li class="list-group-item">{{file.name}}</li>
                 {{/each}}
               </ul>

--- a/web/app/components/submission-form/confirm.gts
+++ b/web/app/components/submission-form/confirm.gts
@@ -116,6 +116,8 @@ export default class SubmissionFormConfirmComponent extends Component<Signature>
 
                 {{#if (eq @state.selection.via "dfast")}}
                   <li>{{t "submission-form.files.a1"}}</li>
+                {{else if (eq @state.selection.via "ggs")}}
+                  <li>{{t "submission-form.files.a4"}}</li>
                 {{else if (eq @state.selection.via "webui")}}
                   <li>{{t "submission-form.files.a2"}}</li>
                 {{else if (eq @state.selection.via "mass_directory")}}

--- a/web/app/components/submission-form/files.gts
+++ b/web/app/components/submission-form/files.gts
@@ -4,30 +4,15 @@ import { service } from '@ember/service';
 
 import { t } from 'ember-intl';
 import { task } from 'ember-concurrency';
-import svgJar from 'ember-svg-jar/helpers/svg-jar';
 
-import FileList from 'mssform/components/file-list';
-import JobIdExtractor from 'mssform/components/job-id-extractor';
-import SupportedFileTypes from 'mssform/components/file-list/supported-file-types';
-import MassDirectoryExtractor from 'mssform/components/mass-directory-extractor';
-import RadioGroup from 'mssform/components/radio-group';
-import userMassDir from 'mssform/helpers/user-mass-dir';
+import FileChooser from 'mssform/components/file-chooser';
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
 import OtherPerson from 'mssform/models/other-person';
-import { discardFiles } from 'mssform/models/submission-file';
-import {
-  collectCrossoverErrors,
-  hasBlockingErrors,
-  validateDuplicates,
-  validatePairs,
-  validateSameness,
-} from 'mssform/utils/crossover-errors';
 
 import type { paths } from 'schema/openapi';
 import type Submission from 'mssform/models/submission';
 import type { Navigation, State } from 'mssform/components/submission-form';
 import type { RequestManager } from '@warp-drive/core';
-import type { SubmissionFileData } from 'mssform/models/submission-file';
 
 export interface Signature {
   Args: {
@@ -39,45 +24,6 @@ export interface Signature {
 
 export default class SubmissionFormFilesComponent extends Component<Signature> {
   @service declare requestManager: RequestManager;
-
-  // A new submission has to arrive complete: whole pairs, agreeing with each
-  // other.
-  get crossoverErrors() {
-    return collectCrossoverErrors(this.args.state.files, [validateDuplicates, validatePairs, validateSameness]);
-  }
-
-  get isNextButtonEnabled() {
-    const { uploadVia } = this.args.model;
-    const { files } = this.args.state;
-
-    if (!uploadVia) return false;
-    if (!files.length) return false;
-
-    return !hasBlockingErrors(files, this.crossoverErrors);
-  }
-
-  @action setUploadVia(val: string) {
-    discardFiles(this.args.state.files);
-
-    this.args.model.uploadVia = val;
-    this.args.model.extractionId = undefined;
-    this.args.state.files = [];
-  }
-
-  @action onExtractProgress({ id, files }: { id: number; files: SubmissionFileData[] }) {
-    this.args.model.extractionId = id;
-    this.args.state.files = files;
-  }
-
-  @action addFile(file: SubmissionFileData) {
-    this.args.state.files = [...this.args.state.files, file];
-  }
-
-  @action removeFile(file: SubmissionFileData) {
-    discardFiles([file]);
-
-    this.args.state.files = this.args.state.files.filter((f) => f !== file);
-  }
 
   @action handleSubmit(event: Event) {
     event.preventDefault();
@@ -132,7 +78,7 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
 
   fillDataFromSubmissionFiles() {
     const { state, model } = this.args;
-    const { files } = state;
+    const { files } = state.selection;
 
     const annotationFile = files.find((file) => file.fileType === 'annotation');
 
@@ -151,119 +97,10 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
 
   <template>
     <form {{on "submit" this.handleSubmit}} {{leavingConfirmation}}>
-      <div class="vstack gap-3">
-        <div class="card">
-          <div class="card-body">
-            {{t "submission-form.files.q-html" htmlSafe=true}}
-
-            <RadioGroup as |group|>
-              <div class="form-check">
-                <group.radio as |radio|>
-                  <radio.input
-                    checked={{eq @model.uploadVia "dfast"}}
-                    required
-                    class="form-check-input"
-                    {{on "change" (fn this.setUploadVia "dfast")}}
-                  />
-
-                  <radio.label class="form-check-label">
-                    {{t "submission-form.files.a1"}}
-                  </radio.label>
-                </group.radio>
-              </div>
-
-              <div class="form-check">
-                <group.radio as |radio|>
-                  <radio.input
-                    checked={{eq @model.uploadVia "ggs"}}
-                    required
-                    class="form-check-input"
-                    {{on "change" (fn this.setUploadVia "ggs")}}
-                  />
-
-                  <radio.label class="form-check-label">
-                    {{t "submission-form.files.a4"}}
-                  </radio.label>
-                </group.radio>
-              </div>
-
-              <div class="form-check">
-                <group.radio as |radio|>
-                  <radio.input
-                    checked={{eq @model.uploadVia "webui"}}
-                    required
-                    class="form-check-input"
-                    {{on "change" (fn this.setUploadVia "webui")}}
-                  />
-
-                  <radio.label class="form-check-label">
-                    {{t "submission-form.files.a2"}}
-                  </radio.label>
-                </group.radio>
-              </div>
-
-              <div class="hstack gap-3">
-                <div class="form-check">
-                  <group.radio as |radio|>
-                    <radio.input
-                      checked={{eq @model.uploadVia "mass_directory"}}
-                      required
-                      class="form-check-input"
-                      {{on "change" (fn this.setUploadVia "mass_directory")}}
-                    />
-
-                    <radio.label class="form-check-label">
-                      {{t "submission-form.files.a3-html" htmlSafe=true userMassDir=(userMassDir)}}
-                    </radio.label>
-
-                    {{t "submission-form.files.a3-note-html" htmlSafe=true}}
-                  </group.radio>
-                </div>
-
-                <small>
-                  <a href={{t "submission-form.files.a3-help-url"}} target="_blank" rel="noopener noreferrer">
-                    {{svgJar "question-16" class="octicon" width="14px" style="margin-top: 2px"}}
-                    {{t "submission-form.files.a3-help-text"}}
-                  </a>
-                </small>
-              </div>
-            </RadioGroup>
-          </div>
-        </div>
-
-        {{#if (eq @model.uploadVia "dfast")}}
-          <JobIdExtractor
-            @endpoint="/dfast_extractions"
-            @i18nPrefix="dfast-extractor"
-            @onPoll={{this.onExtractProgress}}
-            @crossoverErrors={{this.crossoverErrors}}
-          />
-        {{else if (eq @model.uploadVia "ggs")}}
-          <JobIdExtractor
-            @endpoint="/ggs_extractions"
-            @i18nPrefix="ggs-extractor"
-            @onPoll={{this.onExtractProgress}}
-            @crossoverErrors={{this.crossoverErrors}}
-          />
-        {{else if (eq @model.uploadVia "webui")}}
-          <div class="card">
-            <div class="card-body">
-              {{t "submission-form.files.instructions-html" htmlSafe=true}}
-
-              <SupportedFileTypes />
-
-              <FileList
-                @files={{@state.files}}
-                @crossoverErrors={{this.crossoverErrors}}
-                @onAdd={{this.addFile}}
-                @onRemove={{this.removeFile}}
-              />
-            </div>
-          </div>
-        {{else if (eq @model.uploadVia "mass_directory")}}
-          <MassDirectoryExtractor @onPoll={{this.onExtractProgress}} @crossoverErrors={{this.crossoverErrors}} />
-        {{/if}}
-      </div>
+      <FileChooser @selection={{@state.selection}}>
+        <:question>{{t "submission-form.files.q-html" htmlSafe=true}}</:question>
+        <:instructions>{{t "submission-form.files.instructions-html" htmlSafe=true}}</:instructions>
+      </FileChooser>
 
       <hr />
 
@@ -275,7 +112,7 @@ export default class SubmissionFormFilesComponent extends Component<Signature> {
         <button
           type="submit"
           class="btn btn-primary px-5"
-          disabled={{not (and this.isNextButtonEnabled this.goNext.isIdle)}}
+          disabled={{not (and @state.selection.isSubmittable this.goNext.isIdle)}}
         >{{t "submission-form.nav.next"}}</button>
       </div>
     </form>

--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -3,30 +3,18 @@ import { LinkTo } from '@ember/routing';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { trackedArray } from '@ember/reactive/collections';
 
 import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
-import svgJar from 'ember-svg-jar/helpers/svg-jar';
 
-import FileList from 'mssform/components/file-list';
-import JobIdExtractor from 'mssform/components/job-id-extractor';
-import SupportedFileTypes from 'mssform/components/file-list/supported-file-types';
-import MassDirectoryExtractor from 'mssform/components/mass-directory-extractor';
-import RadioGroup from 'mssform/components/radio-group';
+import FileChooser from 'mssform/components/file-chooser';
 import UploadProgressModal from 'mssform/components/upload-progress-modal';
-import userMassDir from 'mssform/helpers/user-mass-dir';
-import { discardFiles } from 'mssform/models/submission-file';
-import {
-  collectCrossoverErrors,
-  hasBlockingErrors,
-  validateDuplicates,
-  validateSameness,
-} from 'mssform/utils/crossover-errors';
+import FileSelection from 'mssform/models/file-selection';
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
+import { validateDuplicates, validateSameness } from 'mssform/utils/crossover-errors';
 
 import type { RequestManager } from '@warp-drive/core';
-import type { SubmissionFile, SubmissionFileData } from 'mssform/models/submission-file';
+import type { SubmissionFile } from 'mssform/models/submission-file';
 import type UploadProgressModalComponent from 'mssform/components/upload-progress-modal';
 
 interface DirectUploadBlob {
@@ -46,9 +34,6 @@ export interface Signature {
 export default class UploadFormComponent extends Component<Signature> {
   @service declare requestManager: RequestManager;
 
-  @tracked uploadVia: string | null = null;
-  @tracked extractionId: number | null = null;
-  files: SubmissionFileData[] = trackedArray();
   @tracked isCompleted = false;
 
   // Re-uploading often means replacing one half of a pair, so a lone annotation
@@ -56,61 +41,25 @@ export default class UploadFormComponent extends Component<Signature> {
   // takes whole pairs only. The rest still holds: the same name twice is a
   // mistake, and the annotation files sent together have to agree on the
   // contact person and the hold date the submission already has.
-  get crossoverErrors() {
-    return collectCrossoverErrors(this.files, [validateDuplicates, validateSameness]);
-  }
-
-  get isSubmitButtonEnabled() {
-    const { uploadVia, files } = this;
-
-    if (!uploadVia) return false;
-    if (!files.length) return false;
-
-    return !hasBlockingErrors(files, this.crossoverErrors);
-  }
+  selection = new FileSelection([validateDuplicates, validateSameness]);
 
   willDestroy() {
     super.willDestroy();
 
-    discardFiles(this.files);
-  }
-
-  @action setUploadVia(val: string) {
-    discardFiles(this.files);
-
-    this.uploadVia = val;
-    this.files.length = 0;
-    this.extractionId = null;
-  }
-
-  @action onExtractProgress({ id, files }: { id: number; files: SubmissionFileData[] }) {
-    this.extractionId = id;
-    this.files.length = 0;
-    this.files.push(...files);
-  }
-
-  @action addFile(file: SubmissionFileData) {
-    this.files.push(file);
-  }
-
-  @action removeFile(file: SubmissionFileData) {
-    const index = this.files.indexOf(file);
-
-    if (index === -1) return;
-
-    discardFiles([file]);
-
-    this.files.splice(index, 1);
+    this.selection.discard();
   }
 
   @action async submit(uploadProgressModal: UploadProgressModalComponent, event: Event) {
     event.preventDefault();
+
+    const { selection } = this;
+
     const attrs: Record<string, unknown> = {
-      via: this.uploadVia,
+      via: selection.via,
     };
 
-    if (this.uploadVia == 'webui') {
-      const blobs = (await uploadProgressModal.performUpload(this.files as SubmissionFile[])) as unknown as
+    if (selection.via === 'webui') {
+      const blobs = (await uploadProgressModal.performUpload(selection.files as SubmissionFile[])) as unknown as
         DirectUploadBlob[] | undefined;
 
       // The upload failed and was surfaced in the error modal, or it was
@@ -119,7 +68,7 @@ export default class UploadFormComponent extends Component<Signature> {
 
       attrs['files'] = blobs.map((blob) => blob.signed_id);
     } else {
-      attrs['extraction_id'] = this.extractionId;
+      attrs['extraction_id'] = selection.extractionId;
     }
 
     await this.requestManager.request({
@@ -148,123 +97,15 @@ export default class UploadFormComponent extends Component<Signature> {
 
       <UploadProgressModal as |modal|>
         <form {{on "submit" (fn this.submit modal)}} {{leavingConfirmation}}>
-          <div class="vstack gap-3">
-            <div class="card">
-              <div class="card-body">
-                <RadioGroup as |group|>
-                  <div class="form-check">
-                    <group.radio as |radio|>
-                      <radio.input
-                        checked={{eq this.uploadVia "dfast"}}
-                        required
-                        class="form-check-input"
-                        {{on "change" (fn this.setUploadVia "dfast")}}
-                      />
+          <FileChooser @selection={{this.selection}}>
+            <:instructions>{{t "upload-form.instructions-html" htmlSafe=true}}</:instructions>
+          </FileChooser>
 
-                      <radio.label class="form-check-label">
-                        {{t "submission-form.files.a1"}}
-                      </radio.label>
-                    </group.radio>
-                  </div>
-
-                  <div class="form-check">
-                    <group.radio as |radio|>
-                      <radio.input
-                        checked={{eq this.uploadVia "ggs"}}
-                        required
-                        class="form-check-input"
-                        {{on "change" (fn this.setUploadVia "ggs")}}
-                      />
-
-                      <radio.label class="form-check-label">
-                        {{t "submission-form.files.a4"}}
-                      </radio.label>
-                    </group.radio>
-                  </div>
-
-                  <div class="form-check">
-                    <group.radio as |radio|>
-                      <radio.input
-                        checked={{eq this.uploadVia "webui"}}
-                        required
-                        class="form-check-input"
-                        {{on "change" (fn this.setUploadVia "webui")}}
-                      />
-
-                      <radio.label class="form-check-label">
-                        {{t "submission-form.files.a2"}}
-                      </radio.label>
-                    </group.radio>
-                  </div>
-
-                  <div class="hstack gap-3">
-                    <div class="form-check">
-                      <group.radio as |radio|>
-                        <radio.input
-                          checked={{eq this.uploadVia "mass_directory"}}
-                          required
-                          class="form-check-input"
-                          {{on "change" (fn this.setUploadVia "mass_directory")}}
-                        />
-
-                        <radio.label class="form-check-label">
-                          {{t "submission-form.files.a3-html" htmlSafe=true userMassDir=(userMassDir)}}
-                        </radio.label>
-
-                        {{t "submission-form.files.a3-note-html" htmlSafe=true}}
-                      </group.radio>
-                    </div>
-
-                    <small>
-                      <a href={{t "submission-form.files.a3-help-url"}} target="_blank" rel="noopener noreferrer">
-                        {{svgJar "question-16" class="octicon" width="14px" style="margin-top: 2px"}}
-                        {{t "submission-form.files.a3-help-text"}}
-                      </a>
-                    </small>
-                  </div>
-                </RadioGroup>
-              </div>
-            </div>
-
-            {{#if (eq this.uploadVia "dfast")}}
-              <JobIdExtractor
-                @endpoint="/dfast_extractions"
-                @i18nPrefix="dfast-extractor"
-                @onPoll={{this.onExtractProgress}}
-                @crossoverErrors={{this.crossoverErrors}}
-              />
-            {{else if (eq this.uploadVia "ggs")}}
-              <JobIdExtractor
-                @endpoint="/ggs_extractions"
-                @i18nPrefix="ggs-extractor"
-                @onPoll={{this.onExtractProgress}}
-                @crossoverErrors={{this.crossoverErrors}}
-              />
-            {{else if (eq this.uploadVia "webui")}}
-              <div class="card">
-                <div class="card-body">
-                  {{t "upload-form.instructions-html" htmlSafe=true}}
-
-                  <SupportedFileTypes />
-
-                  <FileList
-                    @files={{this.files}}
-                    @crossoverErrors={{this.crossoverErrors}}
-                    @onAdd={{this.addFile}}
-                    @onRemove={{this.removeFile}}
-                  />
-                </div>
-              </div>
-            {{else if (eq this.uploadVia "mass_directory")}}
-              <MassDirectoryExtractor @onPoll={{this.onExtractProgress}} @crossoverErrors={{this.crossoverErrors}} />
-            {{/if}}
-          </div>
-
-          {{#if this.uploadVia}}
+          {{#if this.selection.via}}
             <hr />
 
             <div class="text-end">
-              <button type="submit" disabled={{not this.isSubmitButtonEnabled}} class="btn btn-primary px-5">{{t
+              <button type="submit" disabled={{not this.selection.isSubmittable}} class="btn btn-primary px-5">{{t
                   "upload-form.upload"
                 }}</button>
             </div>

--- a/web/app/models/file-selection.ts
+++ b/web/app/models/file-selection.ts
@@ -1,0 +1,65 @@
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import { discardFiles } from 'mssform/models/submission-file';
+import { collectCrossoverErrors, hasBlockingErrors } from 'mssform/utils/crossover-errors';
+
+import type { SubmissionFileData } from 'mssform/models/submission-file';
+import type { Validation } from 'mssform/utils/crossover-errors';
+
+// The files a form is about to send, and how they were chosen. Which checks
+// they answer to is the form's decision: a new submission and a re-upload do
+// not go by the same rules.
+export default class FileSelection {
+  @tracked via?: string;
+  @tracked extractionId?: number;
+  @tracked files: SubmissionFileData[] = [];
+
+  #validations: Validation[];
+
+  constructor(validations: Validation[]) {
+    this.#validations = validations;
+  }
+
+  get crossoverErrors() {
+    return collectCrossoverErrors(this.files, this.#validations);
+  }
+
+  // Whether these files can be sent as they stand.
+  get isSubmittable() {
+    if (!this.via) return false;
+    if (!this.files.length) return false;
+
+    return !hasBlockingErrors(this.files, this.crossoverErrors);
+  }
+
+  @action setVia(via: string) {
+    this.discard();
+
+    this.via = via;
+    this.extractionId = undefined;
+    this.files = [];
+  }
+
+  @action addFile(file: SubmissionFileData) {
+    this.files = [...this.files, file];
+  }
+
+  @action removeFile(file: SubmissionFileData) {
+    discardFiles([file]);
+
+    this.files = this.files.filter((f) => f !== file);
+  }
+
+  // An extraction reports the files it has found so far, replacing what it
+  // reported before.
+  @action onExtractProgress({ id, files }: { id: number; files: SubmissionFileData[] }) {
+    this.extractionId = id;
+    this.files = files;
+  }
+
+  // Stops whatever is still running for these files.
+  discard() {
+    discardFiles(this.files);
+  }
+}

--- a/web/app/models/submission.ts
+++ b/web/app/models/submission.ts
@@ -6,8 +6,6 @@ import type OtherPerson from 'mssform/models/other-person';
 export default class Submission {
   @tracked id?: string;
   @tracked tpa: boolean | null = null;
-  @tracked uploadVia?: string;
-  @tracked extractionId?: number;
   @tracked files: string[] = [];
   @tracked entriesCount?: number;
   @tracked holdDate?: string;

--- a/web/app/utils/crossover-errors.ts
+++ b/web/app/utils/crossover-errors.ts
@@ -2,7 +2,7 @@ import type { SubmissionError, SubmissionFileData } from 'mssform/models/submiss
 
 export type CrossoverErrors = Map<SubmissionFileData, SubmissionError[]>;
 
-type Validation = (errors: CrossoverErrors, files: SubmissionFileData[]) => void;
+export type Validation = (errors: CrossoverErrors, files: SubmissionFileData[]) => void;
 
 // Errors a file only has in the company of the others being sent with it, as
 // opposed to the ones its parser found in it on its own. Which of them apply

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -124,6 +124,8 @@ module('Acceptance | submission', function (hooks) {
   setupAuthentication(hooks);
 
   test('new submission via webui upload', async function (assert) {
+    let submitted: { submission?: { upload_via?: string; files?: string[] } } | undefined;
+
     worker.use(
       http.get('/submissions', ({ response }) => {
         return response(200).json({
@@ -135,7 +137,9 @@ module('Acceptance | submission', function (hooks) {
         return new HttpResponse(null, { status: 404 });
       }),
 
-      http.post('/submissions', ({ response }) => {
+      http.post('/submissions', async ({ request, response }) => {
+        submitted = await request.json();
+
         return response(200).json({
           submission: { id: 'NSUB000001' },
         });
@@ -210,6 +214,9 @@ module('Acceptance | submission', function (hooks) {
     await waitUntil(() => getRootElement().textContent?.includes('NSUB000001'));
 
     assert.dom().containsText('NSUB000001', 'MASS ID is displayed');
+
+    assert.strictEqual(submitted?.submission?.upload_via, 'webui');
+    assert.deepEqual(submitted?.submission?.files, ['test-signed-id', 'test-signed-id']);
   });
 
   test('the unacceptable TPA answer cannot proceed past the prerequisite step', async function (assert) {
@@ -238,6 +245,8 @@ module('Acceptance | submission', function (hooks) {
   });
 
   test('new submission via DFAST job ID', async function (assert) {
+    let submitted: { submission?: { upload_via?: string; extraction_id?: number } } | undefined;
+
     const extractionFiles = [
       {
         name: '01234567-89ab-cdef-0000-000000000001/test.ann',
@@ -298,7 +307,9 @@ module('Acceptance | submission', function (hooks) {
         });
       }),
 
-      http.post('/submissions', ({ response }) => {
+      http.post('/submissions', async ({ request, response }) => {
+        submitted = await request.json();
+
         return response(200).json({
           submission: { id: 'NSUB000002' },
         });
@@ -358,6 +369,9 @@ module('Acceptance | submission', function (hooks) {
     await waitUntil(() => getRootElement().textContent?.includes('NSUB000002'));
 
     assert.dom().containsText('NSUB000002', 'MASS ID is displayed');
+
+    assert.strictEqual(submitted?.submission?.upload_via, 'dfast');
+    assert.strictEqual(submitted?.submission?.extraction_id, 1);
   });
 
   test('new submission via mass directory', async function (assert) {

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -605,6 +605,7 @@ module('Acceptance | submission', function (hooks) {
     // --- Step 4: Confirm ---
 
     assert.dom('button[type="submit"]').hasText('Apply for registration');
+    assert.dom().containsText('Import the submission files from GGS Job ID', 'the chosen method is confirmed');
 
     await click('#agree-terms');
     await click('button[type="submit"]');

--- a/web/tests/acceptance/upload-test.gts
+++ b/web/tests/acceptance/upload-test.gts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, click, findAll, getRootElement, triggerEvent, waitUntil } from '@ember/test-helpers';
+import { visit, click, fillIn, findAll, getRootElement, triggerEvent, waitFor, waitUntil } from '@ember/test-helpers';
 import { setupApplicationTest } from 'mssform/tests/helpers';
 import { setupAuthentication } from 'mssform/tests/helpers/setup-auth';
 import clickRadio from 'mssform/tests/helpers/click-radio';
@@ -76,6 +76,66 @@ module('Acceptance | upload', function (hooks) {
     await waitUntil(() => getRootElement().textContent?.includes('Go to home'));
 
     assert.deepEqual(uploaded, { upload: { via: 'webui', files: ['test-signed-id'] } });
+  });
+
+  test('adding files imported from a job', async function (assert) {
+    let uploaded: unknown;
+
+    worker.use(
+      http.post('/dfast_extractions', ({ response }) => {
+        return response(201).json({
+          _self: '/dfast_extractions/1',
+          id: 1,
+          state: 'pending',
+          error: null,
+          files: [],
+        });
+      }),
+
+      http.get('/dfast_extractions/{id}', ({ response }) => {
+        return response(200).json({
+          _self: '/dfast_extractions/1',
+          id: 1,
+          state: 'fulfilled',
+          error: null,
+
+          files: [
+            {
+              name: '01234567-89ab-cdef-0000-000000000001/test.fasta',
+              basename: 'test',
+              size: 50,
+              isParsing: false,
+              parsedData: { entriesCount: 1 },
+              isParseSucceeded: true,
+              errors: [],
+              fileType: 'sequence' as const,
+              jobId: '01234567-89ab-cdef-0000-000000000001',
+            },
+          ],
+        });
+      }),
+
+      http.post('/submissions/{mass_id}/uploads', async ({ request }) => {
+        uploaded = await request.json();
+
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await visit('/home/submission/NSUB000001/upload');
+
+    await clickRadio('Import the submission files from DFAST Job ID');
+    await fillIn('textarea', '01234567-89ab-cdef-0000-000000000001');
+    await click('.card-body button[type="submit"]');
+
+    await waitFor('.list-group-item');
+
+    await click('button.px-5[type="submit"]');
+
+    await waitUntil(() => getRootElement().textContent?.includes('Go to home'));
+
+    // An import sends what to copy, not the files themselves.
+    assert.deepEqual(uploaded, { upload: { via: 'dfast', extraction_id: 1 } });
   });
 
   test('a warning does not stand in the way', async function (assert) {


### PR DESCRIPTION
The follow-up to #1630. The submission form's file step and the upload form asked the same question — which way are the files coming, and which ones — in two copies: the four radios, the extractor and file-list branches, and the four actions that keep the answer. That is where the two of them drifted apart twice (#1630 fixed the drift; this removes the copy).

- `models/file-selection.ts` — `FileSelection` holds the answer: the method, the extraction it came from, the files, the checks that apply to them, and whether they can be sent.
- `components/file-chooser.gts` — renders the choosing, and takes what the two forms word differently as blocks (`:question`, `:instructions`).

Each form is left with what it does with the selection afterwards: the wizard fills the metadata from it and moves on, the upload form posts it to an existing submission. Together they lose about 370 lines and gain about 210.

The wizard keeps its selection in `State`, where the files already lived, because it outlives the step that makes it — putting the teardown on the step component instead fails four acceptance tests, which is how that was learned in #1626. `Submission` loses `uploadVia` and `extractionId`: they were only ever written by that step and read at submit time, which is now the selection's answer to give.

## Tests

No behaviour change is intended, and the suite covers all four upload methods in the wizard plus the upload route. What was missing is what each form actually submits: the submission form never asserted its payload, and the upload form only did for files it uploads itself. Both now pin the import case too — the exact wiring this moves — and each assertion was checked against a mutation.

The second commit is separate and is a real fix: the confirmation step lists how the files were provided and has said **nothing for GGS** since that import was added, because the branch was written for the three methods that existed then. The acceptance test walked past it without looking; now it looks.