### PR TITLE
Take the error modal's backdrop down with it

### DIFF
--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -80,6 +80,10 @@ export default class UploadFormComponent extends Component<Signature> {
       },
     });
 
+    // The files are with the submission now, and this form is replaced by its
+    // completion message: nothing here will read them again.
+    selection.discard();
+
     this.isCompleted = true;
   }
 

--- a/web/app/controllers/application.ts
+++ b/web/app/controllers/application.ts
@@ -29,6 +29,11 @@ export default class ApplicationController extends Controller {
 
     return () => {
       el.removeEventListener('hidden.bs.modal', handler);
+
+      // Bootstrap keeps the backdrop and the scroll lock on <body>, outside
+      // this element: destroying it while the modal is open would strand them
+      // there. Safe to do at once, this modal is not animated.
+      this.errorModal?.hide();
     };
   });
 

--- a/web/app/templates/application.gts
+++ b/web/app/templates/application.gts
@@ -46,7 +46,11 @@ interface Signature {
     {{outlet}}
   </div>
 
-  <div class="modal fade" tabindex="-1" {{@controller.setErrorModal}}>
+  {{! Not animated: Bootstrap re-appends a modal to <body> if its show
+  transition is still pending when the element goes away, and an error is
+  better shown at once than faded in anyway. The upload progress modal is
+  not animated for the same reason. }}
+  <div class="modal" tabindex="-1" {{@controller.setErrorModal}}>
     <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
       <div class="modal-content">
         <div class="modal-header">

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -729,8 +729,8 @@ module('Acceptance | submission', function (hooks) {
 
       // Bootstrap appends the backdrop to `<body>`, outside the application's
       // root element, so it has to be looked up in the document. Identify it by
-      // what the submit click adds rather than by counting: earlier tests can
-      // leave backdrops of their own behind.
+      // what the submit click adds rather than by counting, so that this does
+      // not depend on how many modals the page has open.
       const backdrops = new Set(document.querySelectorAll('.modal-backdrop'));
 
       await click('button.px-5[type="submit"]');

--- a/web/tests/helpers/index.ts
+++ b/web/tests/helpers/index.ts
@@ -15,7 +15,29 @@ function resetHandlers(hooks: NestedHooks) {
   });
 }
 
+// Bootstrap puts a modal's backdrop and scroll lock on `<body>`, out of Ember's
+// reach, and only takes them down when the modal is hidden. Registered before
+// the application's own teardown so that it runs after it, this says whether
+// the application cleaned up after itself.
+function assertNothingLeftOnBody(hooks: NestedHooks) {
+  hooks.afterEach(function (assert) {
+    assert.dom('.modal-backdrop', document.body).doesNotExist('the application leaves no backdrop behind');
+    assert.dom(document.body).doesNotHaveClass('modal-open');
+
+    // Cleaned up either way, so that a leak fails the test that made it rather
+    // than every test that runs after it.
+    for (const backdrop of document.body.querySelectorAll('.modal-backdrop')) {
+      backdrop.remove();
+    }
+
+    document.body.classList.remove('modal-open');
+    document.body.style.removeProperty('overflow');
+    document.body.style.removeProperty('padding-right');
+  });
+}
+
 function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
+  assertNothingLeftOnBody(hooks);
   upstreamSetupApplicationTest(hooks, options);
   resetHandlers(hooks);
 }


### PR DESCRIPTION
The two leftovers from #1637.

## The error modal left its backdrop on `<body>`

Bootstrap puts a modal's backdrop and the scroll lock on `<body>`, out of Ember's reach, and only takes them down when the modal is hidden. The error modal was neither hidden nor animated away when its element went, so every test that showed one left a backdrop and an `overflow: hidden` behind — measured: 2 modals, 2 backdrops and a stuck `overflow` at the end of a run.

It is hidden on teardown now, the way the upload progress modal already is, and **it no longer fades**. An animated modal cannot be torn down at once, and Bootstrap re-appends one to `<body>` if its show transition is still pending when the element goes away — which is what put stale modals in front of the tests that used to hunt for them through `document`, the flake that started this whole series (#1622). An error is better shown at once than faded in anyway, and the app's two modals now behave the same way.

The listener removal has to stay above the hide, or the `hidden.bs.modal` it raises would clear `error` on a controller that is being destroyed.

### Asserted, not swept

Every application test now asserts it left no backdrop and no `modal-open` behind, and then clears both. The clearing matters as much as the assertion: without it, one leak fails ten tests and the cause is buried under the collateral damage. With it, bringing back either the fade or the missing hide fails exactly the two tests that show the error modal.

## The upload form kept its selection after finishing

Smaller than it looked. Nothing is still running for those files by the time the upload lands — the upload waits for every checksum, and a file still being parsed keeps the submit button off — so this changes nothing today. It stops the form from depending on that reasoning.