### PR TITLE
Send the submitter back to their submission after uploading

### DIFF
--- a/web/app/components/upload-form.gts
+++ b/web/app/components/upload-form.gts
@@ -1,8 +1,6 @@
 import Component from '@glimmer/component';
-import { LinkTo } from '@ember/routing';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 import { t } from 'ember-intl';
 import pageTitle from 'ember-page-title/helpers/page-title';
@@ -13,6 +11,7 @@ import FileSelection from 'mssform/models/file-selection';
 import leavingConfirmation from 'mssform/modifiers/leaving-confirmation';
 import { validateDuplicates, validateSameness } from 'mssform/utils/crossover-errors';
 
+import type RouterService from '@ember/routing/router-service';
 import type { RequestManager } from '@warp-drive/core';
 import type { SubmissionFile } from 'mssform/models/submission-file';
 import type UploadProgressModalComponent from 'mssform/components/upload-progress-modal';
@@ -33,8 +32,7 @@ export interface Signature {
 
 export default class UploadFormComponent extends Component<Signature> {
   @service declare requestManager: RequestManager;
-
-  @tracked isCompleted = false;
+  @service declare router: RouterService;
 
   // Re-uploading often means replacing one half of a pair, so a lone annotation
   // or sequence file is expected here -- unlike in the submission form, which
@@ -80,42 +78,48 @@ export default class UploadFormComponent extends Component<Signature> {
       },
     });
 
-    // The files are with the submission now, and this form is replaced by its
-    // completion message: nothing here will read them again.
+    // The files are with the submission now, and nothing here will read them
+    // again.
     selection.discard();
 
-    this.isCompleted = true;
+    // The submitter may have left while this was in flight: there is no
+    // submission route left to refresh, nor a page of theirs to take over.
+    if (this.isDestroying || this.isDestroyed) return;
+
+    // Back to the submission, which lists what has been uploaded to it. The
+    // submission's own model has to be fetched again for the upload just made
+    // to be among them -- but after arriving rather than before, so that a
+    // failure there leaves the submitter on their submission, where the upload
+    // plainly went through, instead of on an error page that suggests it did
+    // not. The failure itself still reaches the error modal.
+    await this.router.transitionTo('submission.index');
+
+    await this.router.refresh('submission').catch(() => {});
   }
 
   <template>
     {{pageTitle (t "upload-form.title")}}
 
-    {{#if this.isCompleted}}
-      {{t "upload-form.complete-html" htmlSafe=true}}
+    <h1 class="display-6 my-4">{{t "upload-form.title"}}</h1>
 
-      <LinkTo @route="home">{{t "go-to-home"}}</LinkTo>
-    {{else}}
-      <h1 class="display-6 my-4">{{t "upload-form.title"}}</h1>
+    {{t "upload-form.description-html" massId=@model.id htmlSafe=true}}
 
-      {{t "upload-form.description-html" massId=@model.id htmlSafe=true}}
+    <UploadProgressModal as |modal|>
+      <form {{on "submit" (fn this.submit modal)}} {{leavingConfirmation}}>
+        <FileChooser @selection={{this.selection}}>
+          <:instructions>{{t "upload-form.instructions-html" htmlSafe=true}}</:instructions>
+        </FileChooser>
 
-      <UploadProgressModal as |modal|>
-        <form {{on "submit" (fn this.submit modal)}} {{leavingConfirmation}}>
-          <FileChooser @selection={{this.selection}}>
-            <:instructions>{{t "upload-form.instructions-html" htmlSafe=true}}</:instructions>
-          </FileChooser>
+        {{#if this.selection.via}}
+          <hr />
 
-          {{#if this.selection.via}}
-            <hr />
-
-            <div class="text-end">
-              <button type="submit" disabled={{not this.selection.isSubmittable}} class="btn btn-primary px-5">{{t
-                  "upload-form.upload"
-                }}</button>
-            </div>
-          {{/if}}
-        </form>
-      </UploadProgressModal>
-    {{/if}}
+          <div class="text-end">
+            <button type="submit" disabled={{not this.selection.isSubmittable}} class="btn btn-primary px-5">{{t
+                "upload-form.upload"
+              }}</button>
+          </div>
+        {{/if}}
+      </form>
+    </UploadProgressModal>
   </template>
 }

--- a/web/app/templates/submission/index.gts
+++ b/web/app/templates/submission/index.gts
@@ -31,6 +31,8 @@ interface Signature {
 
   <h2 class="mt-4">{{t "submission.show.submission-files"}}</h2>
 
+  {{t "submission.show.notice-html" htmlSafe=true}}
+
   <div class="vstack gap-3">
     {{#each (sortById @model.uploads) as |upload|}}
       <div class="card">

--- a/web/tests/acceptance/upload-test.gts
+++ b/web/tests/acceptance/upload-test.gts
@@ -1,5 +1,15 @@
 import { module, test } from 'qunit';
-import { visit, click, fillIn, findAll, getRootElement, triggerEvent, waitFor, waitUntil } from '@ember/test-helpers';
+import {
+  visit,
+  click,
+  currentURL,
+  fillIn,
+  findAll,
+  settled,
+  triggerEvent,
+  waitFor,
+  waitUntil,
+} from '@ember/test-helpers';
 import { setupApplicationTest } from 'mssform/tests/helpers';
 import { setupAuthentication } from 'mssform/tests/helpers/setup-auth';
 import clickRadio from 'mssform/tests/helpers/click-radio';
@@ -34,7 +44,13 @@ module('Acceptance | upload', function (hooks) {
   setupApplicationTest(hooks);
   setupAuthentication(hooks);
 
+  // The files of an upload are copied by a background job, so a fresh one is
+  // listed with none of them yet.
+  let uploads: { id: number; created_at: string; files: string[]; job_ids: string[] }[];
+
   hooks.beforeEach(function () {
+    uploads = [];
+
     worker.use(
       http.get('/submissions/{mass_id}', ({ response }) => {
         return response(200).json({
@@ -43,7 +59,7 @@ module('Acceptance | upload', function (hooks) {
             created_at: '2026-08-14T00:00:00Z',
             status: null,
             accessions: [],
-            uploads: [],
+            uploads,
           },
         });
       }),
@@ -56,6 +72,7 @@ module('Acceptance | upload', function (hooks) {
     worker.use(
       http.post('/submissions/{mass_id}/uploads', async ({ request }) => {
         uploaded = await request.json();
+        uploads = [{ id: 1, created_at: '2026-08-16T00:00:00Z', files: [], job_ids: [] }];
 
         return new HttpResponse(null, { status: 204 });
       }),
@@ -73,9 +90,17 @@ module('Acceptance | upload', function (hooks) {
 
     await click('button.px-5[type="submit"]');
 
-    await waitUntil(() => getRootElement().textContent?.includes('Go to home'));
+    // Sending is not tracked by `settled`, so wait for where it ends up. The
+    // query string carries the locale, and this page's own URL starts with the
+    // one it leaves for.
+    await waitUntil(() => currentURL()?.split('?')[0] === '/home/submission/NSUB000001');
+    await settled();
 
     assert.deepEqual(uploaded, { upload: { via: 'webui', files: ['test-signed-id'] } });
+
+    // The submission lists what was just added to it, which is the answer the
+    // submitter is after.
+    assert.dom('.card').exists({ count: 1 }, 'the upload is listed');
   });
 
   test('adding files imported from a job', async function (assert) {
@@ -117,6 +142,7 @@ module('Acceptance | upload', function (hooks) {
 
       http.post('/submissions/{mass_id}/uploads', async ({ request }) => {
         uploaded = await request.json();
+        uploads = [{ id: 1, created_at: '2026-08-16T00:00:00Z', files: [], job_ids: [] }];
 
         return new HttpResponse(null, { status: 204 });
       }),
@@ -132,7 +158,7 @@ module('Acceptance | upload', function (hooks) {
 
     await click('button.px-5[type="submit"]');
 
-    await waitUntil(() => getRootElement().textContent?.includes('Go to home'));
+    await waitUntil(() => currentURL()?.split('?')[0] === '/home/submission/NSUB000001');
 
     // An import sends what to copy, not the files themselves.
     assert.deepEqual(uploaded, { upload: { via: 'dfast', extraction_id: 1 } });

--- a/web/translations/en.yaml
+++ b/web/translations/en.yaml
@@ -218,10 +218,6 @@ upload-form:
 
   upload: Upload
 
-  complete-html: |
-    <h1 class="display-6 my-4">Upload completed</h1>
-    <p>You will receive an email from mass@ddbj.nig.ac.jp to the address you entered. Please do not (re-)send submission files as an email attachment.</p>
-
 file-list:
   add-files: Add files
   stats: "{filesCount, plural, =1 {1 file} other {# files}}, {totalFileSize}"
@@ -287,3 +283,6 @@ ggs-extractor:
 submission.show:
   re-upload: Re-upload
   submission-files: Submission files
+
+  notice-html: |
+    <p>You will receive an email from mass@ddbj.nig.ac.jp to the address you entered. Please do not (re-)send submission files as an email attachment.</p>

--- a/web/translations/ja.yaml
+++ b/web/translations/ja.yaml
@@ -219,10 +219,6 @@ upload-form:
 
   upload: アップロード
 
-  complete-html: |
-    <h1 class="display-6 my-4">アップロード完了</h1>
-    <p>mass@ddbj.nig.ac.jp より、入力いただいたアドレス宛にメールが通知されます。メール添付での登録ファイル(再)送付はご遠慮ください。</p>
-
 file-list:
   add-files: ファイルの追加
   stats: "{filesCount} ファイル、{totalFileSize}"
@@ -288,3 +284,6 @@ ggs-extractor:
 submission.show:
   re-upload: 再アップロード
   submission-files: 登録ファイル
+
+  notice-html: |
+    <p>mass@ddbj.nig.ac.jp より、入力いただいたアドレス宛にメールが通知されます。メール添付での登録ファイル(再)送付はご遠慮ください。</p>


### PR DESCRIPTION
The odd shape noted at the end of #1638. The upload form stood in for the page it came from once it had sent anything: an `isCompleted` flag swapped the form for a completion message while the URL still said `/upload`. Reloading brought back the empty form, and the way onward was a link **home** rather than to the submission the files had just been added to.

It transitions back to the submission instead, which already lists what was uploaded and when — the concrete answer the submitter is after.

## Two things the review turned up

**The list is fetched again after arriving, not before.** It has to be fetched at all for the new upload to show (the parent route's model is not re-run by the transition), but doing it first means a failure there drops the submitter on a full-page error with the URL still saying `/upload` — after an upload that went through. The plausible next move is to upload again, which the backend accepts: a second upload, a second copy job, a second pair of emails. Refreshing after arriving leaves them on their submission, where the upload plainly landed, and the failure still reaches the error modal.

**Leaving the form while the upload is in flight stops the transition.** Otherwise `refresh` runs against a route that is no longer active — an assertion in development, and in production a transition that drags the submitter off whatever page they went to.

## The message

"You will receive an email from mass@ddbj.nig.ac.jp… do not send submission files as an email attachment" was only shown in the moment after uploading, though it is true all the time. It moves to the submission page and stays there.

## Note

The files of a new upload are copied by a background job, so the entry appears with its timestamp before its file names. The tests mock it that way.