### PR TITLE
Let an upload answer for its files before they are copied

### DIFF
--- a/app/models/concerns/extraction_upload.rb
+++ b/app/models/concerns/extraction_upload.rb
@@ -10,12 +10,14 @@ module ExtractionUpload
   end
 
   def copy_files_to_submissions_dir
-    upload.files_dir.mkpath
-
-    extraction.files.find_each do |file|
-      FileUtils.cp file.fullpath, upload.files_dir
+    stage_files do |work|
+      extraction.files.find_each do |file|
+        FileUtils.cp file.fullpath, work
+      end
     end
+  end
 
-    trim_annotation_fields!
+  def source_file_names
+    extraction.files.pluck(:name).sort
   end
 end

--- a/app/models/concerns/upload_via.rb
+++ b/app/models/concerns/upload_via.rb
@@ -6,9 +6,27 @@ module UploadVia
 
   included do
     has_one :upload, as: :via, touch: true, dependent: :destroy
+
+    delegate :submission, to: :upload
   end
 
   private
+
+  # Gathers the files aside and moves them into place in one go, so that the
+  # directory is never seen half filled -- neither by the curator it is handed
+  # to, nor by the submitter, who is told what the upload holds from where it
+  # came from until it is there.
+  def stage_files
+    work = submission.root_dir.join("../.work/#{submission.mass_id}-#{upload.timestamp}")
+    work.mkpath
+
+    yield work
+
+    upload.files_dir.dirname.mkpath
+    work.rename upload.files_dir
+
+    trim_annotation_fields!
+  end
 
   def trim_annotation_fields!
     upload.files_dir.glob '*' do |path|

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -14,6 +14,13 @@ class Upload < ApplicationRecord
 
   delegated_type :via, types: VIA.values, dependent: :destroy
 
+  # The files this upload consists of. They are copied into place in the
+  # background, in one move, so until that has happened the names are known
+  # only where they came from.
+  def file_names
+    Dir.glob('*.*', base: files_dir).presence || via.source_file_names
+  end
+
   def files_dir
     submission.root_dir.join(timestamp)
   end

--- a/app/models/webui_upload.rb
+++ b/app/models/webui_upload.rb
@@ -3,8 +3,6 @@ class WebuiUpload < ApplicationRecord
 
   has_many_attached :files
 
-  delegate :submission, to: :upload
-
   def self.from_params(files:, **)
     new(files:)
   end
@@ -12,23 +10,21 @@ class WebuiUpload < ApplicationRecord
   def copy_files_to_submissions_dir
     return if copied?
 
-    work = submission.root_dir.join("../.work/#{submission.mass_id}-#{upload.timestamp}")
-    work.mkpath
-
-    files.each do |attachment|
-      work.join(attachment.filename.to_s).open 'wb' do |f|
-        attachment.download do |chunk|
-          f.write chunk
+    stage_files do |work|
+      files.each do |attachment|
+        work.join(attachment.filename.to_s).open 'wb' do |f|
+          attachment.download do |chunk|
+            f.write chunk
+          end
         end
       end
     end
 
-    upload.files_dir.dirname.mkpath
-    work.rename upload.files_dir
-
-    trim_annotation_fields!
-
     update! copied: true, files: []
+  end
+
+  def source_file_names
+    files.blobs.map { _1.filename.to_s }.sort
   end
 
   def job_ids = nil

--- a/app/views/submissions/_submission.json.jb
+++ b/app/views/submissions/_submission.json.jb
@@ -11,7 +11,7 @@ state = working_list_states[submission.mass_id]
     {
       id:         upload.id,
       created_at: upload.created_at.iso8601,
-      files:      Dir.glob('*.*', base: upload.files_dir),
+      files:      upload.file_names,
       job_ids:    upload.via.job_ids || []
     }
   }

--- a/test/fixtures/files/test.fasta
+++ b/test/fixtures/files/test.fasta
@@ -1,0 +1,2 @@
+>entry1
+ATCG

--- a/test/integration/submissions_test.rb
+++ b/test/integration/submissions_test.rb
@@ -66,6 +66,71 @@ class SubmissionsTest < ActionDispatch::IntegrationTest
     assert_conform_schema 200
   end
 
+  test 'show (files not copied yet)' do
+    submission = submissions(:alice_submission)
+    upload     = submission.uploads.create!(via: WebuiUpload.new(files: [fixture_file_upload('test.fasta', 'text/plain')]))
+
+    get "/api/submissions/#{submission.mass_id}"
+
+    assert_conform_schema 200
+
+    # The copy job has not run, so nothing is on disk: the upload answers for
+    # the files it was given.
+    assert_empty Dir.glob('*', base: upload.files_dir)
+
+    files = response.parsed_body['submission']['uploads'].find { _1['id'] == upload.id }['files']
+
+    assert_equal ['test.fasta'], files
+  end
+
+  test 'show (files copied)' do
+    submission = submissions(:alice_submission)
+    upload     = submission.uploads.create!(via: WebuiUpload.new(files: [fixture_file_upload('test.fasta', 'text/plain')]))
+
+    upload.via.copy_files_to_submissions_dir
+
+    get "/api/submissions/#{submission.mass_id}"
+
+    assert_conform_schema 200
+
+    files = response.parsed_body['submission']['uploads'].find { _1['id'] == upload.id }['files']
+
+    assert_equal ['test.fasta'], files
+  end
+
+  test 'show (imported files not copied yet)' do
+    submission = submissions(:alice_submission)
+    extraction = dfast_extractions(:alice_dfast_extraction)
+
+    extraction.working_dir.mkpath
+
+    %w[test.ann test.fasta].each do |name|
+      extraction.files.create!(name:, dfast_job_id: 'job-1', parsing: false)
+
+      FileUtils.touch extraction.working_dir.join(name)
+    end
+
+    upload = submission.uploads.create!(via: DfastUpload.new(extraction:))
+
+    get "/api/submissions/#{submission.mass_id}"
+
+    assert_conform_schema 200
+
+    files = response.parsed_body['submission']['uploads'].find { _1['id'] == upload.id }['files']
+
+    assert_equal %w[test.ann test.fasta], files
+
+    # And the same once they have been copied, which happens in one move so
+    # that the list never shrinks in between.
+    upload.via.copy_files_to_submissions_dir
+
+    get "/api/submissions/#{submission.mass_id}"
+
+    files = response.parsed_body['submission']['uploads'].find { _1['id'] == upload.id }['files']
+
+    assert_equal %w[test.ann test.fasta], files
+  end
+
   test 'show (not found)' do
     get '/api/submissions/NSUB999999'
 

--- a/test/models/extraction_upload_test.rb
+++ b/test/models/extraction_upload_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class ExtractionUploadTest < ActiveSupport::TestCase
+  test 'a copy that fails partway leaves nothing behind' do
+    submission = submissions(:alice_submission)
+    extraction = dfast_extractions(:alice_dfast_extraction)
+
+    extraction.working_dir.mkpath
+
+    %w[test.ann test.fasta].each do |name|
+      extraction.files.create!(name:, dfast_job_id: 'job-1', parsing: false)
+
+      FileUtils.touch extraction.working_dir.join(name)
+    end
+
+    upload = submission.uploads.create!(via: DfastUpload.new(extraction:))
+    copied = 0
+
+    cp = ->(src, dest) {
+      copied += 1
+
+      raise 'the copy broke down' if copied > 1
+
+      FileUtils.copy(src, dest)
+    }
+
+    FileUtils.stub :cp, cp do
+      assert_raises(RuntimeError) { upload.via.copy_files_to_submissions_dir }
+    end
+
+    # The submission is told what the upload holds from the extraction until the
+    # files are there. A directory holding some of them would be reported as all
+    # there is, and the list the submitter sees would shrink.
+    assert_empty Dir.glob('*', base: upload.files_dir)
+  end
+end

--- a/web/tests/acceptance/upload-test.gts
+++ b/web/tests/acceptance/upload-test.gts
@@ -44,8 +44,6 @@ module('Acceptance | upload', function (hooks) {
   setupApplicationTest(hooks);
   setupAuthentication(hooks);
 
-  // The files of an upload are copied by a background job, so a fresh one is
-  // listed with none of them yet.
   let uploads: { id: number; created_at: string; files: string[]; job_ids: string[] }[];
 
   hooks.beforeEach(function () {
@@ -72,7 +70,10 @@ module('Acceptance | upload', function (hooks) {
     worker.use(
       http.post('/submissions/{mass_id}/uploads', async ({ request }) => {
         uploaded = await request.json();
-        uploads = [{ id: 1, created_at: '2026-08-16T00:00:00Z', files: [], job_ids: [] }];
+
+        // An upload answers for its files from the moment it exists, even
+        // though they are copied into place afterwards.
+        uploads = [{ id: 1, created_at: '2026-08-16T00:00:00Z', files: ['test.fasta'], job_ids: [] }];
 
         return new HttpResponse(null, { status: 204 });
       }),
@@ -101,6 +102,7 @@ module('Acceptance | upload', function (hooks) {
     // The submission lists what was just added to it, which is the answer the
     // submitter is after.
     assert.dom('.card').exists({ count: 1 }, 'the upload is listed');
+    assert.dom('.list-group-item').hasText('test.fasta', 'with the file that was sent');
   });
 
   test('adding files imported from a job', async function (assert) {
@@ -142,7 +144,15 @@ module('Acceptance | upload', function (hooks) {
 
       http.post('/submissions/{mass_id}/uploads', async ({ request }) => {
         uploaded = await request.json();
-        uploads = [{ id: 1, created_at: '2026-08-16T00:00:00Z', files: [], job_ids: [] }];
+
+        uploads = [
+          {
+            id: 1,
+            created_at: '2026-08-16T00:00:00Z',
+            files: ['test.fasta'],
+            job_ids: ['01234567-89ab-cdef-0000-000000000001'],
+          },
+        ];
 
         return new HttpResponse(null, { status: 204 });
       }),


### PR DESCRIPTION
Follow-up to #1639: the submission page needed a reload before a fresh upload's files appeared.

An upload's `files` were read off the directory it is copied *to*, and that copying happens in a background job — for a webui upload it downloads every file out of storage first, so on a large submission the submitter looks at an upload with a timestamp and nothing else for a while, with no way to tell that anything arrived short of reloading.

The names are known before any of that: from the attachments for a webui upload, and from the extraction for an import. An upload now answers with those until the copy has happened.

## Imports land in one move now

For that to hold *while* a copy is running, an import has to land the way a webui upload already does: gathered aside, then moved into place in one go. Copying file by file into the submission's directory would have made the list shrink to what had arrived so far and grow back — and it left a half-filled directory for the curator too. The staging step is now shared by both upload types.

## What this changes about `files`

It means what the upload consists of, rather than what is on disk. That is the submitter's question, and the answer they were already given once the copy finished. A copy that fails still leaves the files listed but not delivered — as an empty upload did before. Neither tells the submitter what happened, which is worth addressing on its own.

## Tests

Both branches, for both upload kinds: an upload reports its files before the copy and the same ones after. Plus a model test that a copy failing partway leaves nothing behind — the property that keeps the list from shrinking. Each fails against the code it guards.

## Noticed while here, not fixed

Two GGS jobs holding a file of the same name still overwrite each other during this copy (`FileUtils.cp` into one directory). DFAST and the archive extractor both raise `Extraction::Error.new(:duplicate_file_name, …)` for that; the submission-time copy has no such guard, and the client-side check is the only thing standing in the way. Worth its own look.