### PR TITLE
Reject the same file name coming from two GGS jobs

### DIFF
--- a/app/jobs/extract_metadata_job.rb
+++ b/app/jobs/extract_metadata_job.rb
@@ -4,9 +4,11 @@ class ExtractMetadataJob < ApplicationJob
       begin
         extraction.prepare_files
       rescue Extraction::Error => e
-        # A partly-processed directory may have created some file records
-        # before failing; discard them so a rejected extraction keeps none.
+        # A partly-processed directory may have created some file records and
+        # copied some files before failing; discard both so a rejected
+        # extraction keeps nothing.
         extraction.files.destroy_all
+        extraction.working_dir.rmtree if extraction.working_dir.exist?
         extraction.update! state: 'rejected', error: {id: e.id, **e.data}
         return
       end

--- a/app/models/concerns/archive_extraction.rb
+++ b/app/models/concerns/archive_extraction.rb
@@ -108,8 +108,12 @@ module ArchiveExtraction
       raise Extraction::Error.new(:unreadable_file, reason: "#{src}: #{detail}")
     end
 
-    FileUtils.cp source, dest
-
+    # Record the file before copying it, so a caller that turns the name down
+    # is not paid for in bytes first. Nothing is left half-done either way:
+    # prepare_files runs in a transaction, and a rejected extraction has its
+    # working directory removed.
     build.call name
+
+    FileUtils.cp source, dest
   end
 end

--- a/app/models/ggs_extraction.rb
+++ b/app/models/ggs_extraction.rb
@@ -44,6 +44,13 @@ class GgsExtraction < ApplicationRecord
       end
 
       unarchive_and_copy_files(merged, working_dir.join(job_id)) do |name|
+        # Each job keeps its files to itself here, but a submission copies them
+        # all into one directory, where one would overwrite the other. Name the
+        # job the file clashes with: it is not in front of the submitter.
+        if other = files.find_by(name:)
+          raise Extraction::Error.new(:duplicate_file_name, job_id:, reason: "duplicate file name: #{name} (already imported from job #{other.ggs_job_id})")
+        end
+
         files.create!(name:, parsing: true, ggs_job_id: job_id)
       end
     end

--- a/app/models/ggs_extraction.rb
+++ b/app/models/ggs_extraction.rb
@@ -31,8 +31,8 @@ class GgsExtraction < ApplicationRecord
     [src_dir, src_dir.join('fixed')].each do |dir|
       next unless dir.directory?
 
-      dir.each_child do |child|
-        sources[child.basename.to_s] = child if child.file?
+      dir.children.sort.each do |child|
+        sources[source_name(child)] = child if child.file?
       end
     end
 
@@ -47,6 +47,16 @@ class GgsExtraction < ApplicationRecord
         files.create!(name:, parsing: true, ggs_job_id: job_id)
       end
     end
+  end
+
+  # The same file can be plain in output/ and compressed in output/fixed/, or
+  # the other way round. Key both on the name the import would store, so the
+  # two are recognised as one file instead of colliding once expanded.
+  def source_name(path)
+    name = path.basename.to_s
+    comp = COMPRESS.keys.find { name.end_with?(".#{_1}") }
+
+    comp ? name.delete_suffix(".#{comp}") : name
   end
 
   def job_output_dir(job_id)

--- a/test/jobs/extract_metadata_job_test.rb
+++ b/test/jobs/extract_metadata_job_test.rb
@@ -285,8 +285,10 @@ class ExtractMetadataJobTest < ActiveJob::TestCase
     assert_equal 'invalid_archive', @extraction.error['id']
     assert_match(/\Azzz\.tar: /, @extraction.error['reason'])
 
-    # aaa.ann is copied before zzz.tar fails; the rejection must keep no files.
+    # aaa.ann is copied before zzz.tar fails; the rejection must keep no files,
+    # on disk no more than in the database.
     assert_empty @extraction.files
+    assert_not @extraction.working_dir.exist?
   end
 
   test 'archive: unreadable file (broken symlink)' do

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -31,6 +31,30 @@ class GgsExtractionTest < ActiveSupport::TestCase
     assert files.all? { _1.fullpath.exist? }
   end
 
+  test 'prepare_files rejects the same file name coming from two jobs' do
+    job_ids = ['01234567-89ab-cdef-0000-000000000001', '01234567-89ab-cdef-0000-000000000002']
+
+    job_ids.each do |job_id|
+      dir = output_dir(job_id)
+
+      dir.join('foo.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+      dir.join('foo.fa').write  ">CLN01\nACGT\n"
+    end
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: job_ids)
+
+    # They sit under their own job here, but the submission they are copied to
+    # holds them in one directory.
+    error = assert_raises(Extraction::Error) { extraction.prepare_files }
+
+    assert_equal :duplicate_file_name, error.id
+    assert_equal job_ids.last, error.data[:job_id]
+    assert_equal "duplicate file name: foo.ann (already imported from job #{job_ids.first})", error.data[:reason]
+
+    # The name is turned down before the file it names is copied.
+    assert_not extraction.working_dir.join(job_ids.last, 'foo.ann').exist?
+  end
+
   test 'prepare_files prefers output/fixed/ over output/ for the same file name' do
     job_id = '01234567-89ab-cdef-0000-000000000001'
     dir    = output_dir(job_id)
@@ -169,11 +193,11 @@ class GgsExtractionTest < ActiveSupport::TestCase
     job1 = '01234567-89ab-cdef-0000-000000000001'
     job2 = '01234567-89ab-cdef-0000-000000000002'
 
-    [job1, job2].each do |job_id|
+    {job1 => 'foo', job2 => 'bar'}.each do |job_id, basename|
       dir = output_dir(job_id)
 
-      dir.join('genome.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
-      dir.join('genome.fa').write  ">CLN01\nACGT\n"
+      dir.join("#{basename}.ann").write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+      dir.join("#{basename}.fa").write  ">CLN01\nACGT\n"
     end
 
     extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job1, job2])
@@ -181,6 +205,9 @@ class GgsExtractionTest < ActiveSupport::TestCase
 
     assert_equal 4, extraction.files.count
     assert_equal [job1, job1, job2, job2], extraction.files.order(:ggs_job_id, :name).map(&:ggs_job_id)
+
+    assert_equal [job1, job2], extraction.working_dir.children.map { _1.basename.to_s }.sort
+    assert extraction.files.all? { _1.fullpath.exist? }
   end
 
   test 'prepare_files raises when the job output directory is missing' do

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -51,6 +51,28 @@ class GgsExtractionTest < ActiveSupport::TestCase
     assert_equal ">fixed\nACGT\n",                        files.last.fullpath.read
   end
 
+  test 'prepare_files prefers output/fixed/ when only one of the two is compressed' do
+    job_id = '01234567-89ab-cdef-0000-000000000001'
+    dir    = output_dir(job_id)
+    fixed  = dir.join('fixed').tap(&:mkpath)
+
+    dir.join('foo.fa').write ">output\nACGT\n"
+
+    Zlib::GzipWriter.open(fixed.join('foo.fa.gz')) do |gz|
+      gz.write ">fixed\nACGT\n"
+    end
+
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: [job_id])
+    extraction.prepare_files
+
+    # The two are the same file under different names, so taking both would
+    # have them collide the moment the compressed one is expanded.
+    file = extraction.files.sole
+
+    assert_equal 'foo.fa',         file.name
+    assert_equal ">fixed\nACGT\n", file.fullpath.read
+  end
+
   test 'prepare_files prefers output/fixed/ even when the output/ files are read-only' do
     job_id = '01234567-89ab-cdef-0000-000000000001'
     dir    = output_dir(job_id)


### PR DESCRIPTION
An extraction keeps each GGS job's files under their own directory, so two jobs can each hold a `genome.ann` without either overwriting the other. A submission has no such divide: `ExtractionUpload#copy_files_to_submissions_dir` copies every file into one directory, and the second arrival silently replaced the first — while the upload still listed both.

The DFAST import already rejects this. GGS now does the same, naming the job the file clashes with, since that job's file list is not in front of the submitter. The form blocks it on the way in too, but the API is reachable without it.

Two things found while reviewing that:

- **A rejected extraction left its files behind.** The records were discarded, the bytes stayed in the working directory and nothing ever came back for them. `ExtractMetadataJob` now removes the directory as well.
- **`output/fixed/` lost to `output/` when only one of the two was compressed.** A corrected `foo.fa.gz` next to `output/foo.fa` is a different basename, so both were taken; the compressed one is expanded on import and lands on the other, rejecting the job for a duplicate the submitter cannot see anywhere. The two are now compared by the name the import would store.

The file is also recorded before it is copied, so a name that is going to be turned down is not paid for in bytes first. Both are undone together — `prepare_files` runs in one transaction, and a rejected extraction now has its directory removed.

## Follow-up, not in this PR

`ggs_extraction_files` is unique on `(extraction_id, ggs_job_id, name)`, while DFAST and mass-directory are unique on `(extraction_id, name)`. All three now enforce the same invariant in the application, so GGS is the only one without a database backstop. Tightening the index would need a look at existing rows first — any extraction already holding a cross-job duplicate would fail the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)