### PR TITLE
Let the database hold GGS files to one name per extraction

### DIFF
--- a/db/migrate/20260821023312_tighten_ggs_extraction_file_uniqueness.rb
+++ b/db/migrate/20260821023312_tighten_ggs_extraction_file_uniqueness.rb
@@ -1,0 +1,22 @@
+class TightenGgsExtractionFileUniqueness < ActiveRecord::Migration[8.1]
+  def up
+    # Two GGS jobs could each bring a file of the same name. They were kept
+    # apart under their own job here, but the submission they were copied to
+    # holds them in one directory, so only the last one copied ever reached the
+    # curator. Keep that one, which is the last the copy walks over.
+    execute <<~SQL.squish
+      DELETE FROM ggs_extraction_files
+      WHERE id NOT IN (
+        SELECT MAX(id) FROM ggs_extraction_files GROUP BY extraction_id, name
+      )
+    SQL
+
+    remove_index :ggs_extraction_files, %i[extraction_id ggs_job_id name], unique: true
+    add_index    :ggs_extraction_files, %i[extraction_id name],            unique: true
+  end
+
+  def down
+    remove_index :ggs_extraction_files, %i[extraction_id name],            unique: true
+    add_index    :ggs_extraction_files, %i[extraction_id ggs_job_id name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_28_030629) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_023312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -91,7 +91,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_030629) do
     t.string "name", null: false
     t.jsonb "parsed_data"
     t.boolean "parsing", null: false
-    t.index ["extraction_id", "ggs_job_id", "name"], name: "idx_on_extraction_id_ggs_job_id_name_dc6e405a2b", unique: true
+    t.index ["extraction_id", "name"], name: "index_ggs_extraction_files_on_extraction_id_and_name", unique: true
     t.index ["extraction_id"], name: "index_ggs_extraction_files_on_extraction_id"
   end
 

--- a/test/models/ggs_extraction_test.rb
+++ b/test/models/ggs_extraction_test.rb
@@ -55,6 +55,20 @@ class GgsExtractionTest < ActiveSupport::TestCase
     assert_not extraction.working_dir.join(job_ids.last, 'foo.ann').exist?
   end
 
+  test 'the database refuses the same file name whichever job brought it' do
+    extraction = GgsExtraction.create!(user: users(:alice), ggs_job_ids: ['01234567-89ab-cdef-0000-000000000001'])
+
+    extraction.files.create!(name: 'foo.fa', parsing: false, ggs_job_id: '01234567-89ab-cdef-0000-000000000001')
+
+    # prepare_files turns this down first; the index is what stops a path that
+    # ever forgets to.
+    assert_raises ActiveRecord::RecordNotUnique do
+      extraction.files.create!(name: 'foo.fa', parsing: false, ggs_job_id: '01234567-89ab-cdef-0000-000000000002')
+    end
+
+    assert_equal 1, extraction.files.count
+  end
+
   test 'prepare_files prefers output/fixed/ over output/ for the same file name' do
     job_id = '01234567-89ab-cdef-0000-000000000001'
     dir    = output_dir(job_id)


### PR DESCRIPTION
`ggs_extraction_files` was unique on `(extraction_id, ggs_job_id, name)`, from when two jobs were allowed a file of the same name apiece. #1646 established that they are not — a submission copies every file into one directory, where one would overwrite the other — which left GGS as the only one of the three extraction types without a database backstop under the check that says so. `dfast_extraction_files` and `mass_directory_extraction_files` are both unique on `(extraction_id, name)`.

`ggs_job_id` stays as a column: it is the path segment in `GgsExtractionFile#fullpath` and the provenance shown in the file list. It is just no longer part of what makes a file unique.

## Rows that predate the check

The migration deletes them first, keeping the highest id per `(extraction_id, name)`. That is the row the curator actually received: `copy_files_to_submissions_dir` walks `extraction.files.find_each`, which is primary-key ascending, and copies flat, so the last one copied is the one that survived. Keeping it makes the record agree with the directory.

Deleting whole extractions would have been worse — `ggs_uploads.extraction_id` is a foreign key with no `ON DELETE`, and `GgsUpload#job_ids` reads `extraction.ggs_job_ids` for every submission listing.

Verified by running the migration over real duplicate rows: with `genome.fa` from two jobs and an unpaired `solo.fa`, the job-2 copy and `solo.fa` survive. `down` restores the original index; it cannot bring deleted rows back, which is inherent to any dedupe.

The index swap deliberately stays inside the migration transaction rather than using `algorithm: :concurrently`, which would require `disable_ddl_transaction!` and split the delete from the swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)