### PR TITLE
Sweep up after extractions nobody came back for

### DIFF
--- a/app/jobs/extract_metadata_job.rb
+++ b/app/jobs/extract_metadata_job.rb
@@ -7,8 +7,7 @@ class ExtractMetadataJob < ApplicationJob
         # A partly-processed directory may have created some file records and
         # copied some files before failing; discard both so a rejected
         # extraction keeps nothing.
-        extraction.files.destroy_all
-        extraction.working_dir.rmtree if extraction.working_dir.exist?
+        extraction.discard_files
         extraction.update! state: 'rejected', error: {id: e.id, **e.data}
         return
       end

--- a/app/jobs/purge_extractions_job.rb
+++ b/app/jobs/purge_extractions_job.rb
@@ -1,0 +1,29 @@
+class PurgeExtractionsJob < ApplicationJob
+  # An extraction is scratch space: the files are gathered so the submitter can
+  # look them over, and copied into the submission when they send them. Long
+  # enough that nothing in that exchange is cut short, short enough that what
+  # was thought better of does not sit under the extracts directory for good.
+  RETENTION = 7.days
+
+  def perform
+    extraction_classes.each do |klass|
+      # Every one of them, not only those that still have file records. A
+      # directory is made outside the transaction the records are made in, so a
+      # failure that is not an Extraction::Error rolls the records back and
+      # leaves the directory -- which is the case most worth sweeping, and the
+      # one a records-first query cannot see. discard_files does nothing when
+      # there is nothing to do.
+      klass.where(created_at: ..RETENTION.ago).find_each(&:discard_files)
+    end
+  end
+
+  private
+
+  # Taken from the ways of uploading rather than listed again here, so that a
+  # kind of extraction added later is swept without anyone remembering to.
+  def extraction_classes
+    Upload::VIA.values.map(&:constantize).filter_map {
+      _1.extraction_class if _1.respond_to?(:extraction_class)
+    }
+  end
+end

--- a/app/models/concerns/extraction.rb
+++ b/app/models/concerns/extraction.rb
@@ -23,6 +23,21 @@ module Extraction
     has_many :files, dependent: :destroy, class_name: "#{name}File", foreign_key: :extraction_id
 
     scope :fulfilled, -> { where(state: 'fulfilled') }
+
+    # The gathered files are this extraction's alone. Nothing can find them
+    # once it is gone, so they go with it.
+    after_destroy_commit :remove_working_dir
+  end
+
+  # Lets the gathered files go while keeping the extraction itself: an upload
+  # made from one still names the jobs its files came from.
+  def discard_files
+    # The directory goes first: what is left of it afterwards is something we
+    # could not remove, and once the records are gone there is nothing left
+    # anywhere that says it is there.
+    remove_working_dir
+
+    files.destroy_all
   end
 
   def working_dir
@@ -33,6 +48,14 @@ module Extraction
   end
 
   private
+
+  def remove_working_dir
+    working_dir.rmtree
+
+    # rmtree is rm_rf, which reports nothing at all -- not a missing directory,
+    # which is what we want, and not one it could not remove, which we do.
+    raise "could not remove #{working_dir}" if working_dir.exist?
+  end
 
   def normalize_path(path)
     path.to_s.gsub(%r{[/ ]}, '/' => '__', ' ' => '_')

--- a/app/models/concerns/extraction_upload.rb
+++ b/app/models/concerns/extraction_upload.rb
@@ -11,7 +11,14 @@ module ExtractionUpload
     def from_params(user:, extraction_id: nil, **)
       raise Upload::Malformed, 'extraction_id is missing' if extraction_id.blank?
 
-      new(extraction: extraction_class.fulfilled.where(user:).find(extraction_id))
+      extraction = extraction_class.fulfilled.where(user:).find(extraction_id)
+
+      # Swept up since the submitter last looked at it. Left alone this would
+      # copy an empty directory into place, and that copy is what says the
+      # upload is done: the submission would be finished and empty.
+      raise Upload::Malformed, "extraction #{extraction_id} has no files" if extraction.files.empty?
+
+      new(extraction:)
     end
 
     def extraction_class = reflect_on_association(:extraction).klass
@@ -19,6 +26,10 @@ module ExtractionUpload
 
   def copy_files_to_submissions_dir
     stage_files do |work|
+      # Swept up between the upload being made and this running. Copying nothing
+      # looks exactly like copying everything from here on, so say so instead.
+      raise "#{extraction.class.name} #{extraction.id} has no files to copy" if extraction.files.empty?
+
       extraction.files.find_each do |file|
         FileUtils.cp file.fullpath, work
       end

--- a/app/models/webui_upload.rb
+++ b/app/models/webui_upload.rb
@@ -4,14 +4,15 @@ class WebuiUpload < ApplicationRecord
   has_many_attached :files
 
   # The signed IDs come from a direct upload this submitter just made, so an
-  # empty list means nothing was uploaded, and one we cannot verify was never
-  # issued by us. Neither leaves anything to copy.
+  # empty list means nothing was uploaded; one we cannot verify was never issued
+  # by us; and one whose blob has since been swept up as unattached is a request
+  # that sat for days. None of them leaves anything to copy.
   def self.from_params(files: nil, **)
     raise Upload::Malformed, 'files is missing' if files.blank?
 
     new(files:)
-  rescue ActiveSupport::MessageVerifier::InvalidSignature
-    raise Upload::Malformed, 'files holds a signed ID we did not issue'
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+    raise Upload::Malformed, 'files holds a signed ID we cannot make a file out of'
   end
 
   def copy_files_to_submissions_dir

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -16,3 +16,6 @@ test:
 
 production:
   <<: *default
+
+staging:
+  <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,10 +1,18 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
+production: &production
+  # Both sweep up after what a submitter left behind: the files an extraction
+  # gathered, and the blobs a direct upload made for an application that was
+  # never sent. Overnight, when neither is likely to be in the middle of use,
+  # and behind everything else in the queue -- a backlog of them must not keep
+  # a submitter's own upload waiting.
+  purge_extractions:
+    class: PurgeExtractionsJob
+    priority: 10
+    schedule: at 4am every day
+
+  purge_unattached_uploads:
+    class: PurgeUnattachedUploadsJob
+    priority: 10
+    schedule: at 4:30am every day
+
+staging:
+  <<: *production

--- a/test/integration/submissions/uploads_test.rb
+++ b/test/integration/submissions/uploads_test.rb
@@ -10,6 +10,8 @@ class Submissions::UploadsTest < ActionDispatch::IntegrationTest
 
   test 'create' do
     extraction = @user.dfast_extractions.create!(dfast_job_ids: ['job-1'], state: 'fulfilled')
+
+    extraction.files.create!(name: 'test.ann', dfast_job_id: 'job-1', parsing: false)
     submission = submissions(:alice_submission)
 
     post "/api/submissions/#{submission.mass_id}/uploads", params: {

--- a/test/integration/submissions_test.rb
+++ b/test/integration/submissions_test.rb
@@ -19,6 +19,8 @@ class SubmissionsTest < ActionDispatch::IntegrationTest
   test 'create' do
     extraction = @user.dfast_extractions.create!(dfast_job_ids: ['job-1'], state: 'fulfilled')
 
+    extraction.files.create!(name: 'test.ann', dfast_job_id: 'job-1', parsing: false)
+
     post '/api/submissions', params: {
       submission: {
         tpa:            false,

--- a/test/jobs/purge_extractions_job_test.rb
+++ b/test/jobs/purge_extractions_job_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class PurgeExtractionsJobTest < ActiveJob::TestCase
+  def extraction_with_files(created_at:)
+    extraction = DfastExtraction.create!(user: users(:alice), dfast_job_ids: ['job-1'], state: 'fulfilled', created_at:)
+
+    extraction.working_dir.mkpath
+    extraction.working_dir.join('test.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    extraction.files.create!(name: 'test.ann', dfast_job_id: 'job-1', parsing: false)
+
+    extraction
+  end
+
+  test 'gathered files are let go once nobody is coming back for them' do
+    old = extraction_with_files(created_at: (PurgeExtractionsJob::RETENTION + 1.day).ago)
+
+    PurgeExtractionsJob.perform_now
+
+    assert_not old.working_dir.exist?
+
+    # The records go with the directory: a file left pointing at nothing would
+    # be asked for its size the next time the extraction is rendered.
+    assert_empty old.files.reload
+  end
+
+  test 'a directory left behind with no records to name it' do
+    # A directory is made outside the transaction the records are made in, so a
+    # failure that is not an Extraction::Error rolls the records back and leaves
+    # the directory -- the case most worth sweeping, and the one a query that
+    # starts from the records cannot see.
+    stranded = DfastExtraction.create!(
+      user:           users(:alice),
+      dfast_job_ids:  ['job-1'],
+      created_at:     (PurgeExtractionsJob::RETENTION + 1.day).ago
+    )
+
+    stranded.working_dir.mkpath
+
+    PurgeExtractionsJob.perform_now
+
+    assert_not stranded.working_dir.exist?
+  end
+
+  test 'an extraction still in reach is left alone' do
+    recent = extraction_with_files(created_at: (PurgeExtractionsJob::RETENTION - 1.day).ago)
+
+    PurgeExtractionsJob.perform_now
+
+    assert recent.working_dir.join('test.ann').exist?
+    assert_equal 1, recent.files.reload.count
+  end
+
+  test 'the extraction itself stays, because an upload made from it reads it' do
+    extraction = extraction_with_files(created_at: (PurgeExtractionsJob::RETENTION + 1.day).ago)
+    upload     = submissions(:alice_submission).uploads.create!(via: DfastUpload.new(extraction:))
+
+    PurgeExtractionsJob.perform_now
+
+    assert_equal ['job-1'], upload.via.reload.job_ids
+  end
+end

--- a/test/models/extraction_test.rb
+++ b/test/models/extraction_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+# Behaviour every extraction shares, exercised through one of them.
+class ExtractionTest < ActiveSupport::TestCase
+  setup do
+    @extraction = DfastExtraction.create!(user: users(:alice), dfast_job_ids: ['job-1'])
+
+    @extraction.working_dir.mkpath
+    @extraction.working_dir.join('test.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    @extraction.files.create!(name: 'test.ann', dfast_job_id: 'job-1', parsing: false)
+  end
+
+  test 'discarding the files leaves the extraction' do
+    @extraction.discard_files
+
+    assert_not @extraction.working_dir.exist?
+    assert_empty @extraction.files.reload
+    assert_predicate @extraction.reload, :persisted?
+  end
+
+  test 'destroying the extraction takes the files with it' do
+    @extraction.destroy!
+
+    # Nothing else knows where they are, so nothing else could come back for
+    # them: they would sit under the extracts directory unowned.
+    assert_not @extraction.working_dir.exist?
+  end
+
+  test 'a directory that could not be removed is not passed over in silence' do
+    # rmtree is rm_rf, which reports nothing at all. Without a look afterwards
+    # the records would go and leave a directory nothing knows the whereabouts
+    # of, and nothing would come back for it.
+    FileUtils.stub :rm_rf, nil do
+      assert_raises(RuntimeError) { @extraction.discard_files }
+    end
+
+    assert_equal 1, @extraction.files.reload.count, 'and the records still say where it is'
+  end
+
+  test 'destroying an extraction that gathered nothing' do
+    other = DfastExtraction.create!(user: users(:alice), dfast_job_ids: ['job-2'])
+
+    assert_nothing_raised { other.destroy! }
+  end
+end

--- a/test/models/extraction_upload_test.rb
+++ b/test/models/extraction_upload_test.rb
@@ -31,6 +31,30 @@ class ExtractionUploadTest < ActiveSupport::TestCase
     end
   end
 
+  test 'from_params turns down an extraction whose files have been swept up' do
+    extraction = dfast_extractions(:alice_dfast_extraction)
+
+    extraction.update! state: 'fulfilled'
+
+    # It is still fulfilled and still theirs; there is simply nothing left of it
+    # to copy, and copying nothing is what says an upload is done.
+    assert_raises Upload::Malformed do
+      DfastUpload.from_params(user: users(:alice), extraction_id: extraction.id)
+    end
+  end
+
+  test 'a copy with nothing left to copy is not taken for a finished one' do
+    submission = submissions(:alice_submission)
+    extraction = dfast_extractions(:alice_dfast_extraction)
+    upload     = submission.uploads.create!(via: DfastUpload.new(extraction:))
+
+    # Swept up between the upload being made and the job running. An empty
+    # directory renamed into place cannot be told from a full one afterwards.
+    assert_raises(RuntimeError) { upload.via.copy_files_to_submissions_dir }
+
+    assert_not upload.files_dir.exist?
+  end
+
   test 'from_params turns down a request that names no extraction' do
     assert_raises Upload::Malformed do
       DfastUpload.from_params(user: users(:alice))
@@ -83,8 +107,19 @@ class ExtractionUploadTest < ActiveSupport::TestCase
       DfastUpload         => dfast_extractions(:alice_dfast_extraction),
       GgsUpload           => ggs_extractions(:alice_ggs_extraction),
       MassDirectoryUpload => mass_directory_extractions(:alice_mass_directory_extraction)
-    }.each_value {
-      _1.update! state: 'fulfilled'
+    }.each_value {|extraction|
+      extraction.update! state: 'fulfilled'
+
+      # An extraction with nothing in it is one whose files have been swept up,
+      # and is turned down for that.
+      extraction.files.create!(name: 'test.ann', parsing: false, **job_id_for(extraction))
     }
+  end
+
+  # Only GGS and DFAST tag a file with the job it came from.
+  def job_id_for(extraction)
+    column = extraction.files.build.attribute_names.grep(/_job_id\z/).first
+
+    column ? {column => '01234567-89ab-cdef-0000-000000000001'} : {}
   end
 end

--- a/test/recurring_schedule_test.rb
+++ b/test/recurring_schedule_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'fugit'
+
+class RecurringScheduleTest < ActiveSupport::TestCase
+  # Read at boot by the scheduler Solid Queue starts inside Puma, which aborts
+  # on a job that is not there or a schedule it cannot read -- and the Puma
+  # plugin answers a supervisor that exits by signalling Puma itself. A typo
+  # here does not lose a sweep; it takes the site down at boot.
+  test 'every environment schedules jobs that exist, at times that parse' do
+    config = ActiveSupport::ConfigurationFile.parse(Rails.root.join('config/recurring.yml')).deep_symbolize_keys
+
+    %i[production staging].each do |env|
+      tasks = config.fetch(env)
+
+      assert tasks.any?, "#{env} schedules nothing"
+
+      tasks.each do |id, task|
+        assert Object.const_defined?(task.fetch(:class)), "#{env}/#{id} names a job that is not there"
+
+        # Solid Queue takes a cron and nothing else: 'every 2 hours' parses, as
+        # a Fugit::Duration, and is turned down all the same.
+        assert_kind_of Fugit::Cron, Fugit.parse(task.fetch(:schedule), multi: :fail),
+                       "#{env}/#{id} is not scheduled at a time Solid Queue takes"
+      end
+    end
+  end
+end


### PR DESCRIPTION
An extraction gathers a submitter's files under `extracts_dir/<type>-<id>` so they can look them over, and a submission copies them into place from there. Nothing ever came back for what was left. A rejected extraction had its directory removed; every other one — sent, or thought better of — kept it for good.

`config/recurring.yml` turned out to be the generated file, entirely commented out, so **there is no recurring schedule at all** — which means `PurgeUnattachedUploadsJob`, which has existed in `app/jobs/` all along, has never run either. The blobs a direct upload made for an application that was never sent have been accumulating in SeaweedFS the same way.

Both are swept overnight now, at `priority: 10` so they sit behind everything else: a backlog that has been gathering since the first deploy must not keep a submitter's own upload waiting.

## What is kept

An extraction lets its files go a week on, by which time they have been copied into the submission or will not be. The extraction row itself stays, because `GgsUpload#job_ids` reads `extraction.ggs_job_ids` for every submission listing — deleting it would break the rendering of uploads made from it.

The file records go with the directory rather than outliving it: a record left pointing at nothing is asked for its `size` the next time the extraction is rendered.

## The extraction that outlives what it held

That asymmetry is worth stating, because it was the sharp edge. A swept extraction is still `fulfilled` and still the submitter's, so `from_params` would happily find it, and `copy_files_to_submissions_dir` would iterate an empty collection, rename an empty directory into place — **and that rename is what marks the copy as done**. The submission would be finished and empty, with nothing raised, nothing logged, and nothing in Sentry. Two reachable ways in: a `CopySubmissionFilesJob` that failed (every `retry_on` is commented out, so one transient error parks it permanently) and is re-run by hand a week later, or a stale `extraction_id` from a tab left open.

Both now say so. Building an upload from a swept extraction is turned down; a copy that finds nothing raises.

## Reaching what a query cannot see

The sweep walks every old extraction, not only those that still have file records. The directory is created outside the transaction the records are created in (`working_dir.mkpath` in `DfastExtraction#fetch_and_copy_files`, the file rows inside `ExtractMetadataJob`'s transaction), so any failure that is **not** an `Extraction::Error` — the crash class behind MSSFORM-68/69/4K/5Z — rolls the records back and leaves the tree behind with nothing pointing at it. That is the case most worth reaching, and a records-first query is exactly blind to it.

`Pathname#rmtree` is `FileUtils.rm_rf`, which reports nothing — not a missing directory, which is what we want, and not one it could not remove, which we do. Production runs on a bind mount shared with submitters, so the directory is removed first and checked afterwards; the records stay to say where it is if it could not be.

Destroying an extraction takes its directory too, which closes the orphans `User`'s `dependent: :destroy` has been leaving.

## The schedule is load-bearing at boot

`SolidQueue::Configuration` validates recurring tasks and `Supervisor.start` calls `abort` on an invalid one; under `SOLID_QUEUE_IN_PUMA` the plugin answers a supervisor that exits by signalling Puma itself. **A typo in `recurring.yml` takes the site down at boot**, not just the sweep. So a test reads the file the same way the scheduler does, checking each job exists and each schedule parses as a `Fugit::Cron` — Solid Queue takes a cron and nothing else, and `Fugit.parse('1 hour')` returns a `Duration` that would be turned down.

## Also

- `WebuiUpload.from_params` rescued only `InvalidSignature`. Once unattached blobs are actually being purged, a signed ID older than two days resolves to a deleted row and raises `RecordNotFound` instead — a 404 where the 422 was meant.
- `config/queue.yml` had no `staging:` key, so staging silently ran Solid Queue's built-in defaults and ignored `JOB_CONCURRENCY`.

## Before the first run

The unattached-blob backlog dates from the app's first deploy and is worth draining by hand once, rather than meeting it at 4:30am.

🤖 Generated with [Claude Code](https://claude.com/claude-code)