### PR TITLE
Give two uploads made in the same second a directory each

### DIFF
--- a/app/models/concerns/upload_via.rb
+++ b/app/models/concerns/upload_via.rb
@@ -23,9 +23,9 @@ module UploadVia
   def stage_files
     return if upload.files_dir.exist?
 
-    # Named after the upload rather than the directory it is bound for: two
-    # uploads made in the same second share that name, and would gather into
-    # each other.
+    # Named after the upload rather than the directory it is bound for, which
+    # is settled while the upload is being made: this runs long afterwards, and
+    # asks nothing of what it was settled to be.
     work = submission.root_dir.join("../.work/#{submission.mass_id}-#{upload.id}")
     work.mkpath
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -15,9 +15,21 @@ class Upload < ApplicationRecord
     VIA.fetch(via.to_s.to_sym) { raise Malformed, "unknown via: #{via.inspect}" }.constantize.from_params(**params)
   end
 
+  TIMESTAMP_FORMAT = '%Y%m%d-%H%M%S'
+
+  private_constant :TIMESTAMP_FORMAT
+
   belongs_to :submission
 
   delegated_type :via, types: VIA.values, dependent: :destroy
+
+  # The name of the directory a submission is handed its files in, which is
+  # also the arrival date the curator sheet gives and what the notification
+  # mail sends them to. Settled once, when the upload is made: nothing that
+  # happens later can move a directory somebody has already been sent to.
+  attr_readonly :files_dir_name
+
+  before_create :assign_files_dir_name
 
   # The files this upload consists of. They are copied into place in the
   # background, in one move, so until that has happened the names are known
@@ -27,14 +39,34 @@ class Upload < ApplicationRecord
   end
 
   def files_dir
-    submission.root_dir.join(timestamp)
-  end
-
-  def timestamp
-    created_at.strftime('%Y%m%d-%H%M%S')
+    submission.root_dir.join(files_dir_name)
   end
 
   def via_ident
     VIA.key(via.class.name)
+  end
+
+  private
+
+  # Two uploads of one submission made in the same second would be handed the
+  # same directory, and the second copied over the first. Tell them apart with a
+  # suffix, which leaves the moment they arrived legible wherever the name is
+  # read as one.
+  def assign_files_dir_name
+    # The submission is held for the rest of this transaction, so that two
+    # uploads arriving at once cannot both find the same name free: the second
+    # waits here, and reads the first once it has landed. Held through a query
+    # rather than submission.lock!, which reloads the record and would drop
+    # whatever is still being saved alongside us.
+    Submission.lock.where(id: submission_id).pick(:id)
+
+    base  = created_at.strftime(TIMESTAMP_FORMAT)
+    taken = Upload.where(submission_id:).pluck(:files_dir_name)
+
+    self.files_dir_name = (0..).lazy.map {
+      _1.zero? ? base : "#{base}-#{_1}"
+    }.find {
+      taken.exclude?(_1)
+    }
   end
 end

--- a/app/models/upload_event_log.rb
+++ b/app/models/upload_event_log.rb
@@ -5,7 +5,7 @@ class UploadEventLog
     line = {
       mass_id:           submission.mass_id,
       dway_account:      submission.user.uid,
-      data_arrival_date: upload.timestamp
+      data_arrival_date: upload.files_dir_name
     }.to_json
 
     path = Rails.application.config_for(:app).upload_events_log!

--- a/app/models/working_list.rb
+++ b/app/models/working_list.rb
@@ -74,7 +74,7 @@ class WorkingList
       other_person:               submission.other_people.order(:position).map(&:email_address_with_name).join('; '),
       dway_account:               submission.user.uid,
       dway_account_email:         submission.user.email,
-      data_arrival_date:          submission.uploads.map(&:timestamp).join('; '),
+      data_arrival_date:          submission.uploads.map(&:files_dir_name).join('; '),
       check_start_date:           nil,
       finish_date:                nil,
       sequencer:                  submission.sequencer_text,

--- a/app/views/submission_mailer/curator_notification.text.erb
+++ b/app/views/submission_mailer/curator_notification.text.erb
@@ -27,7 +27,7 @@
 
 ## data_arrival_date
 <% @submission.uploads.each do |upload| -%>
-<%= upload.timestamp %>: <%= upload.files_dir %>
+<%= upload.files_dir_name %>: <%= upload.files_dir %>
 <% end -%>
 
 ## sequencer

--- a/db/migrate/20260821050245_add_files_dir_name_to_uploads.rb
+++ b/db/migrate/20260821050245_add_files_dir_name_to_uploads.rb
@@ -1,0 +1,55 @@
+class AddFilesDirNameToUploads < ActiveRecord::Migration[8.1]
+  TIMESTAMP_FORMAT = '%Y%m%d-%H%M%S'
+
+  def up
+    add_column :uploads, :files_dir_name, :string
+
+    backfill
+
+    change_column_null :uploads, :files_dir_name, false
+
+    add_index :uploads, %i[submission_id files_dir_name], unique: true
+
+    # Now led by the composite above, which answers every lookup it did.
+    remove_index :uploads, :submission_id
+  end
+
+  def down
+    add_index    :uploads, :submission_id
+    remove_index :uploads, %i[submission_id files_dir_name], unique: true
+    remove_column :uploads, :files_dir_name
+  end
+
+  private
+
+  # The name each upload was worked out to have until now, so that every
+  # directory already handed over to a curator keeps the name it was handed over
+  # under. Written here rather than in SQL because the moment is read in the
+  # application's time zone, and to_char would read it in the database's.
+  #
+  # Two uploads of one submission made in the same second shared a directory --
+  # the reason for this column. They cannot both keep that name, so the later
+  # one takes the suffix it would be given today; its directory is the one they
+  # shared, which is now the earlier upload's alone.
+  def backfill
+    uploads = Class.new(ActiveRecord::Base) { self.table_name = 'uploads' }
+
+    uploads.order(:id).group_by(&:submission_id).each_value do |group|
+      taken = []
+
+      group.each do |upload|
+        base = upload.created_at.strftime(TIMESTAMP_FORMAT)
+        name = (0..).lazy.map { _1.zero? ? base : "#{base}-#{_1}" }.find { taken.exclude?(_1) }
+
+        # Named, because it is the only record there will be of which uploads
+        # were affected: this one shared a directory that is now the earlier
+        # upload's alone, and has none of its own to be sent to.
+        say "upload #{upload.id} shared #{base}, and is #{name} now", true unless name == base
+
+        taken << name
+
+        upload.update_column :files_dir_name, name
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_023312) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_050245) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -167,11 +167,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_023312) do
 
   create_table "uploads", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "files_dir_name", null: false
     t.bigint "submission_id", null: false
     t.datetime "updated_at", null: false
     t.bigint "via_id", null: false
     t.string "via_type", null: false
-    t.index ["submission_id"], name: "index_uploads_on_submission_id"
+    t.index ["submission_id", "files_dir_name"], name: "index_uploads_on_submission_id_and_files_dir_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/uploads.yml
+++ b/test/fixtures/uploads.yml
@@ -1,3 +1,5 @@
 alice_upload:
-  submission: alice_submission
-  via:        one (WebuiUpload)
+  submission:     alice_submission
+  via:            one (WebuiUpload)
+  created_at:     2022-01-02 12:34:56
+  files_dir_name: 20220102-123456

--- a/test/models/upload_test.rb
+++ b/test/models/upload_test.rb
@@ -1,11 +1,101 @@
 require 'test_helper'
 
 class UploadTest < ActiveSupport::TestCase
+  setup do
+    @submission = submissions(:alice_submission)
+  end
+
+  def upload_at(time)
+    @submission.uploads.create!(via: WebuiUpload.new, created_at: time)
+  end
+
   test 'build_via turns down a way of uploading we do not have' do
     ['sftp', '', nil].each do |via|
       assert_raises Upload::Malformed do
         Upload.build_via(via:, user: users(:alice))
       end
+    end
+  end
+
+  test 'the directory is named after the moment the files arrived' do
+    assert_equal '20220304-010203', upload_at('2022-03-04 01:02:03').files_dir_name
+  end
+
+  test 'a second upload in the same second is told apart by a suffix' do
+    first  = upload_at('2022-03-04 01:02:03')
+    second = upload_at('2022-03-04 01:02:03')
+    third  = upload_at('2022-03-04 01:02:03')
+
+    # The moment stays legible -- it is what the curator sheet gives as the
+    # arrival date -- and no upload is handed a directory another already has.
+    assert_equal %w[20220304-010203 20220304-010203-1 20220304-010203-2],
+                 [first, second, third].map(&:files_dir_name)
+
+    assert_equal 3, [first, second, third].map(&:files_dir).uniq.size
+  end
+
+  test 'the same second under another submission is not a clash' do
+    other = Submission.create!(
+      mass_id:        'NSUB000042',
+      user:           users(:alice),
+      tpa:            false,
+      entries_count:  1,
+      sequencer:      'ngs',
+      data_type:      'wgs',
+      email_language: 'en',
+
+      contact_person: ContactPerson.new(
+        email:       'alice+contact@example.com',
+        full_name:   'Alice Liddell',
+        affiliation: 'Wonderland Inc.'
+      )
+    )
+
+    upload_at '2022-03-04 01:02:03'
+
+    assert_equal '20220304-010203', other.uploads.create!(via: WebuiUpload.new, created_at: '2022-03-04 01:02:03').files_dir_name
+  end
+
+  test 'the name cannot be changed once it has been handed out' do
+    upload = upload_at('2022-03-04 01:02:03')
+
+    # It is in the curator sheet, in the upload log, and in the mail that sends
+    # them to it. Moving it afterwards would move nothing but the record of it.
+    assert_raises ActiveRecord::ReadonlyAttributeError do
+      upload.update! files_dir_name: 'somewhere-else'
+    end
+
+    assert_equal '20220304-010203', upload.reload.files_dir_name
+  end
+
+  test 'the submission is held while the name is settled' do
+    statements = []
+
+    subscriber = ->(*, payload) { statements << payload[:sql] }
+
+    ActiveSupport::Notifications.subscribed subscriber, 'sql.active_record' do
+      upload_at '2022-03-04 01:02:03'
+    end
+
+    # Two uploads arriving at once would otherwise both find the same name
+    # free, and the second would be turned away by the index rather than given
+    # a directory of its own. Not reachable from a test that runs in one
+    # transaction, so what is asked for is that it is asked for.
+    assert statements.any? { _1.match?(/FROM "submissions".+FOR UPDATE/m) }, 'the submission is not locked'
+  end
+
+  test 'the database refuses two uploads of one submission the same directory' do
+    upload_at '2022-03-04 01:02:03'
+
+    assert_raises ActiveRecord::RecordNotUnique do
+      Upload.insert!({
+        submission_id:  @submission.id,
+        via_type:       'WebuiUpload',
+        via_id:         WebuiUpload.create!.id,
+        files_dir_name: '20220304-010203',
+        created_at:     Time.current,
+        updated_at:     Time.current
+      })
     end
   end
 end


### PR DESCRIPTION
A submission is handed its files in `submission.root_dir.join(<name>)`, where `<name>` was `created_at.strftime('%Y%m%d-%H%M%S')`, worked out afresh on every call. Two uploads of one submission made in the same second got the same name, so the second was copied over the first. Nothing stops that: the submit button is not disabled while the request is in flight, so a double click makes two.

The name now has a suffix where it is taken — `20260821-120000`, then `-1`, then `-2` — so the moment stays legible while each upload gets a directory of its own.

## Written down, not derived

`uploads.files_dir_name` is a column rather than a computation, because the name is **handed over**: `WorkingList#to_row` puts it in the curator sheet's `data_arrival_date`, `UploadEventLog` writes it to the JSONL log, and the curator notification mail sends a curator to it. Nothing that happens later should be able to move a directory somebody has already been pointed at, so it is settled once and `attr_readonly` after that. The database holds it unique per submission.

The submission's row is held while the name is settled, so two arriving at once cannot both find the same one free. Through a query rather than `submission.lock!` — that reloads the record, which drops whatever is still being saved alongside it (the mailer test caught this: `contact_person` came back nil).

## The backfill

The time zone is the sharp edge. `created_at` is stored UTC, but the old code read it through `Time.zone` (`Asia/Tokyo`), so `to_char` in SQL would have renamed **every existing directory** by nine hours. The backfill runs in Ruby for that reason. Verified by rolling back, seeding rows at a known UTC instant and migrating up:

```
2022-01-02 21:34:56 +0900  ->  20220102-213456
2022-01-02 21:34:56 +0900  ->  20220102-213456-1
2022-05-06 16:08:09 +0900  ->  20220506-160809
```

Two old uploads that shared a directory cannot both keep the name; the later takes the suffix, and the migration `say`s which rows those were, since that is the only record there will be. Its directory is the one they shared, which is now the earlier upload's alone — so that upload lists no files rather than claiming the other's. It delivered none: `stage_files` refuses to rename onto a directory that is already there.

## Worth deciding before this ships

- **The migration holds `ACCESS EXCLUSIVE` on `uploads` through the backfill, and the `NOT NULL` lands while the old image is still serving.** `bin/docker-entrypoint` runs `db:prepare` as the new container boots, and Kamal keeps the old one up until it is healthy. A request that arrives during the migration blocks, then completes under the old code, which inserts without the column and hits the NOT NULL — a 500, with the submitter's blobs already in SeaweedFS and no upload row to attach them to. The textbook split is nullable-plus-backfill in one deploy and NOT NULL in the next; a quiet window is the cheaper answer. Since you are deploying overnight this is likely fine, but it should be a decision.
- **`data_arrival_date` can now be `\d{8}-\d{6}-\d+`** in the curator sheet and in `upload_events.jsonl`. Nothing in this repo parses it, but the JSONL was built to a DDBJ-side spec — worth a word to whoever reads it.

## Not fixed here

The duplication itself. A double click still makes two uploads, two directories with identical contents, two curator emails, and two entries in the sheet cell — the curator now has to tell them apart rather than losing one, which is the trade you asked for. Dropping a second submit while one is in flight is the actual fix; I tried it (`task({ drop: true })`) and backed it out, because it makes the cancel-then-retry path unreachable and with it the test that covers the modal bookkeeping from #1622-#1629. It wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)