### PR TITLE
Say which job a file came from, rather than where it isn't

### DIFF
--- a/web/app/components/job-id-extractor.gts
+++ b/web/app/components/job-id-extractor.gts
@@ -110,9 +110,7 @@ export default class JobIdExtractorComponent extends Component<Signature> {
 
       {{#if this.files.length}}
         <ExtractedFiles @files={{this.files}} @crossoverErrors={{@crossoverErrors}} as |file errors|>
-          <SubmissionFileItem @file={{file}} @errors={{errors}}>
-            <:prefix>{{file.jobId}}/</:prefix>
-          </SubmissionFileItem>
+          <SubmissionFileItem @file={{file}} @errors={{errors}} />
         </ExtractedFiles>
       {{/if}}
     </div>

--- a/web/app/components/mass-directory-extractor.gts
+++ b/web/app/components/mass-directory-extractor.gts
@@ -6,7 +6,6 @@ import { tracked } from '@glimmer/tracking';
 
 import ExtractedFiles from 'mssform/components/extracted-files';
 import SubmissionFileItem from 'mssform/components/submission-file-item';
-import userMassDir from 'mssform/helpers/user-mass-dir';
 import Extraction from 'mssform/models/extraction';
 
 import type { ExtractionPayload } from 'mssform/models/extraction';
@@ -53,9 +52,7 @@ export default class MassDirectoryExtractorComponent extends Component<Signature
   <template>
     <div {{this.fetchFiles}} class="card">
       <ExtractedFiles @files={{this.files}} @crossoverErrors={{@crossoverErrors}} as |file errors|>
-        <SubmissionFileItem @file={{file}} @errors={{errors}}>
-          <:prefix>{{userMassDir}}/</:prefix>
-        </SubmissionFileItem>
+        <SubmissionFileItem @file={{file}} @errors={{errors}} />
       </ExtractedFiles>
     </div>
   </template>

--- a/web/app/components/submission-file-item.gts
+++ b/web/app/components/submission-file-item.gts
@@ -13,10 +13,6 @@ interface Signature {
     errors: SubmissionError[];
     onRemove?: (file: SubmissionFileData) => void;
   };
-
-  Blocks: {
-    prefix?: [];
-  };
 }
 
 <template>
@@ -38,10 +34,17 @@ interface Signature {
     </div>
 
     <div class={{if @file.isParsing "opacity-50"}}>
-      {{#if (has-block "prefix")}}<span class="text-body-secondary">{{yield to="prefix"}}</span>{{/if}}{{@file.name}}
+      {{@file.name}}
       <small class="text-body-secondary">{{filesize @file.size}}</small>
 
       <small class="hstack gap-3 text-body-secondary">
+        {{#if @file.jobId}}
+          <div>
+            <b>{{t "file-list.item.job-id"}}</b>
+            {{@file.jobId}}
+          </div>
+        {{/if}}
+
         {{#if @file.isParsing}}
           {{t "file-list.item.loading"}}
         {{else}}

--- a/web/tests/acceptance/submission-test.gts
+++ b/web/tests/acceptance/submission-test.gts
@@ -306,7 +306,7 @@ module('Acceptance | submission', function (hooks) {
 
     const extractionFiles = [
       {
-        name: '01234567-89ab-cdef-0000-000000000001/test.ann',
+        name: 'test.ann',
         basename: 'test',
         size: 100,
         isParsing: false,
@@ -321,7 +321,7 @@ module('Acceptance | submission', function (hooks) {
         jobId: '01234567-89ab-cdef-0000-000000000001',
       },
       {
-        name: '01234567-89ab-cdef-0000-000000000001/test.fasta',
+        name: 'test.fasta',
         basename: 'test',
         size: 50,
         isParsing: false,
@@ -396,6 +396,15 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('.list-group-item');
 
     assert.dom('.list-group-item').exists({ count: 2 });
+
+    // The job is where the files came from, not where they are going: the
+    // submission holds them all in one directory, under the names shown here.
+    for (const item of findAll('.list-group-item')) {
+      assert.dom(item).containsText('Source job 01234567-89ab-cdef-0000-000000000001');
+      assert.dom(item).doesNotContainText('01234567-89ab-cdef-0000-000000000001/');
+    }
+
+    assert.dom('.list-group-item').containsText('test.ann', 'under the name the submission will hold it by');
 
     await click('button.px-5[type="submit"]');
 

--- a/web/tests/unit/translations-test.ts
+++ b/web/tests/unit/translations-test.ts
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'mssform/tests/helpers';
+
+import translationsForEn from 'virtual:ember-intl/translations/en';
+import translationsForJa from 'virtual:ember-intl/translations/ja';
+
+type Translations = Record<string, unknown>;
+
+function keysOf(translations: Translations, prefix = ''): string[] {
+  return Object.entries(translations).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    return value && typeof value === 'object' ? keysOf(value as Translations, path) : [path];
+  });
+}
+
+module('Unit | translations', function (hooks) {
+  setupTest(hooks);
+
+  // There is no fallback locale, and the default is Japanese, so a key added to
+  // one file alone renders as its own name to whoever reads the other.
+  test('the locales say the same things', function (assert) {
+    const en = keysOf(translationsForEn);
+    const ja = keysOf(translationsForJa);
+
+    assert.deepEqual(
+      en.filter((key) => !ja.includes(key)),
+      [],
+      'English says nothing Japanese does not',
+    );
+    assert.deepEqual(
+      ja.filter((key) => !en.includes(key)),
+      [],
+      'Japanese says nothing English does not',
+    );
+  });
+});

--- a/web/translations/en.yaml
+++ b/web/translations/en.yaml
@@ -233,6 +233,7 @@ file-list:
     contact-person: Contact person
     hold-date: Hold date
     entries-count: Number of entries
+    job-id: Source job
     remove: Remove
 
 upload-progress-modal:

--- a/web/translations/ja.yaml
+++ b/web/translations/ja.yaml
@@ -234,6 +234,7 @@ file-list:
     contact-person: コンタクトパーソン
     hold-date: 公開予定日
     entries-count: エントリ数
+    job-id: 取得元ジョブ
     remove: 削除
 
 upload-progress-modal:


### PR DESCRIPTION
An imported file was listed as `<job-id>/<name>`, which reads as the path it will be found at. It is not one — a submission holds every file it is sent in a single directory, under the name shown after the slash — and since #1646 the name is unique across the whole extraction, so the job in front of it corresponds to nothing the submitter will ever see.

Where a file came from is still worth saying: somebody who pasted several job IDs wants to know which brought what. So it is said as a fact about the file, alongside the contact person and the entry count it is already described by, rather than as a place.

## The mass directory prefix was no truer

`MassDirectoryExtractor` glued `{{userMassDir}}/` onto each name the same way. The directory is real, but the name is not what is in it: `Extraction#normalize_path` rewrites `/` to `__` and spaces to `_`, and the glob is recursive and unpacks archives. So

- `<massdir>/run1/foo.ann` is listed as `/submission/alice/mass/run1__foo.ann`
- `<massdir>/my data.ann` as `/submission/alice/mass/my_data.ann`
- `bar.ann` inside `<massdir>/pack.zip` as `/submission/alice/mass/pack__bar.ann`

Only a top-level file with no space in its name gives a path that exists. The submitter is told which directory is read when they choose that option (`submission-form.files.a3-html`), which is where it belongs, so the prefix goes — and with nothing left to put in front of a name, so does the block for it.

## Found while testing

Two mock file names in the DFAST acceptance test were `01234567-…/test.ann`. `normalize_path` means a real name can never contain a slash, and with the old prefix those rows would have rendered `<job-id>/<job-id>/test.ann` — so nothing was checking this display at all. The mocks are realistic now and every row is asserted.

The locales are held to saying the same things, too. There is no `fallbackLocale` and the default locale is `ja`, so a key added to `en.yaml` alone renders as its own name to every submitter reading Japanese, with nothing to say so.

## Not done

For a single-job import the same 36-character UUID now repeats on every row. Showing it only when the extraction spans more than one job would keep the information without the repetition; it needs the count threaded down to the item, so it is a separate change if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)