### PR TITLE
Let go of the blobs left behind in MinIO

### DIFF
--- a/app/jobs/purge_unattached_uploads_job.rb
+++ b/app/jobs/purge_unattached_uploads_job.rb
@@ -1,7 +1,45 @@
 class PurgeUnattachedUploadsJob < ApplicationJob
+  # A blob whose service is gone cannot be purged: what it points at went with
+  # the service, and asking a blob for its service raises. Reported once, rather
+  # than once per blob by the purge that would fail on each of them.
+  class StrandedBlobs < StandardError; end
+
+  # How long a blob a direct upload made is left alone. Long enough for the
+  # application it belongs to to be finished and sent, which WebuiUpload counts
+  # on: a signed ID older than this names a blob that is no longer there.
+  RETENTION = 2.days
+
   queue_as :default
 
   def perform
-    ActiveStorage::Blob.unattached.where(created_at: ..2.days.ago).find_each(&:purge_later)
+    stranded = Hash.new(0)
+
+    ActiveStorage::Blob.unattached.where(created_at: ..RETENTION.ago).find_each do |blob|
+      if service_configured?(blob)
+        blob.purge_later
+      else
+        stranded[blob.service_name] += 1
+      end
+    end
+
+    report stranded if stranded.any?
+  end
+
+  private
+
+  # Whether we could reach the blob at all, not whether it is there. The block
+  # is what makes this a question: without it, fetch raises for a service
+  # nothing is configured for.
+  def service_configured?(blob)
+    ActiveStorage::Blob.services.fetch(blob.service_name) { nil }.present?
+  end
+
+  def report(stranded)
+    counts = stranded.sort.map {|service, count| "#{count} in #{service}" }
+
+    Rails.error.report(
+      StrandedBlobs.new("nothing is configured for the service these blobs name: #{counts.to_sentence}"),
+      handled: true
+    )
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,10 @@
 Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.dsn                = Rails.application.config_for(:app).sentry_dsn
+
+  # Off by default in sentry-rails, which leaves Rails.error.report doing
+  # nothing at all: there is no other subscriber, so anything reported that way
+  # -- ours, and the worker thread errors Solid Queue reports for us -- is
+  # written down nowhere and read by nobody.
+  config.rails.register_error_subscriber = true
 end

--- a/db/migrate/20260822033644_drop_blobs_left_in_minio.rb
+++ b/db/migrate/20260822033644_drop_blobs_left_in_minio.rb
@@ -1,0 +1,35 @@
+class DropBlobsLeftInMinio < ActiveRecord::Migration[8.1]
+  SERVICE = 'minio'.freeze
+
+  # MinIO was replaced by SeaweedFS in March (0ced0557) without moving what was
+  # in it, so the blobs made before that still name a service nothing is
+  # configured for. What they point at went with it: they cannot be purged, only
+  # dropped, and until they are, the nightly sweep tries to purge them and fails
+  # once for each.
+  #
+  # Only the ones nothing is attached to. A blob some upload still holds is as
+  # unreachable, but the attachment is a record of what was sent, and that is
+  # not this migration's to throw away. How many those are is worth knowing:
+  # each one belongs to an upload whose files were never copied into place.
+  def up
+    service = connection.quote(SERVICE)
+
+    attached = select_value(<<~SQL.squish)
+      SELECT COUNT(*) FROM active_storage_blobs b
+      WHERE b.service_name = #{service}
+        AND EXISTS (SELECT 1 FROM active_storage_attachments a WHERE a.blob_id = b.id)
+    SQL
+
+    dropped = execute(<<~SQL.squish).cmd_tuples
+      DELETE FROM active_storage_blobs b
+      WHERE b.service_name = #{service}
+        AND NOT EXISTS (SELECT 1 FROM active_storage_attachments a WHERE a.blob_id = b.id)
+    SQL
+
+    say "dropped #{dropped} blobs left in #{SERVICE}, and left #{attached} that something is still attached to", true
+  end
+
+  # Nothing to undo: what these rows named went with the service, so putting
+  # them back would name it still. Left open so the schema can be rolled past.
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_050245) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_22_033644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/jobs/purge_unattached_uploads_job_test.rb
+++ b/test/jobs/purge_unattached_uploads_job_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+using TmpUploadedFile
+
+class PurgeUnattachedUploadsJobTest < ActiveJob::TestCase
+  def blob(service_name: 'test', created_at: 3.days.ago)
+    ActiveStorage::Blob.create_and_upload!(
+      io:           Rack::Test::UploadedFile.tmp('example.ann'),
+      filename:     'example.ann',
+      service_name: 'test'
+    ).tap {
+      _1.update_columns(service_name:, created_at:)
+    }
+  end
+
+  test 'a blob nothing is attached to is purged' do
+    old = blob
+
+    PurgeUnattachedUploadsJob.perform_now
+
+    assert_enqueued_with job: ActiveStorage::PurgeJob, args: [old]
+  end
+
+  test 'a blob still being offered to a submission is left alone' do
+    recent = blob(created_at: 1.day.ago)
+
+    PurgeUnattachedUploadsJob.perform_now
+
+    assert_no_enqueued_jobs only: ActiveStorage::PurgeJob
+    assert_predicate recent.reload, :persisted?
+  end
+
+  test 'a blob left in a service that is gone is reported, not purged' do
+    stranded = blob(service_name: 'minio')
+
+    reported = capture_error_reports(PurgeUnattachedUploadsJob::StrandedBlobs) do
+      PurgeUnattachedUploadsJob.perform_now
+    end
+
+    # Purging it raises, so the sweep would report it once per blob -- 394 of
+    # them, the night this first ran.
+    assert_no_enqueued_jobs only: ActiveStorage::PurgeJob
+    assert_predicate stranded.reload, :persisted?
+
+    assert_equal 1, reported.size
+    assert_match(/1 in minio/, reported.sole.error.message)
+  end
+end


### PR DESCRIPTION
Fixes MSSFORM-6F.

The nightly sweep #1651 scheduled ran for the first time at 04:30 this morning and raised **394 times**, every one of them:

```
KeyError: Missing configuration for the minio Active Storage service.
Configurations available for the seaweedfs services.
  ActiveStorage::PurgeJob → blob.purge → blob.service → services.fetch(service_name)
```

`0ced0557` (2026-03-19) replaced MinIO with SeaweedFS in `config/storage.yml` and moved no data, so every blob made before that still names a service nothing is configured for. Asking such a blob for its service raises rather than answering, so the purge could only fail.

**It would have failed again tonight.** The blobs stay unattached, so the sweep enqueues the same 394 every night, and `ActiveStorage::PurgeJob` does not retry a `KeyError` — they pile up in `solid_queue_failed_executions` too.

## The data

What those blobs point at went with MinIO. They cannot be purged, only dropped, which is what the migration does — to the ones nothing is attached to. A blob some upload still holds is just as unreachable, but the attachment is a record of what was sent, and that is not this migration's to throw away. It says how many of each it found, since after the fact there is no way to tell whether it matched Sentry's 394.

Verified against seeded rows (unattached minio, attached minio, seaweedfs): the unattached one goes, the other two stay.

`minio` is the only stale name production can hold — `config/storage.yml` has only ever named `test`, `local` (removed three weeks before the first production deploy), `minio` and `seaweedfs`, `config/environments/staging.rb` is a symlink to `production.rb` so staging never diverged, and no credential, deploy file or `service_name:` argument names anything else.

## The sweep

It no longer takes a blob's service on trust. One it cannot reach is counted and reported **once**, naming the service and the count, rather than handed to a purge that fails on each in turn. Fixing the data settles what we know about; this is how we hear about the rest.

## Rails.error.report was reaching nobody

Found while checking that the above would actually be heard: `Rails.error` had **zero subscribers**, confirmed in development and production. sentry-rails leaves `register_error_subscriber` off unless asked, and nothing else subscribes — so anything reported that way was formatted, handed to an empty list, and dropped. Solid Queue reports its worker thread errors through `Rails.error` on our behalf, so those have been going nowhere too. Turned on in its own commit.

(The first version of the test here passed anyway, because it subscribed a subscriber of its own. It uses Rails' `capture_error_reports` now, which also stops it leaking one into every later test.)

## After deploying

- **The 394 failed executions can be discarded or retried, either is safe.** The blobs are gone, so `ActiveJob::Arguments.deserialize` raises `DeserializationError` with `RecordNotFound` as its cause, and `ActiveStorage::PurgeJob`'s `discard_on ActiveRecord::RecordNotFound` matches through `cause` — a retry discards them silently.
- **If the migration reports a non-zero attached count, those are worth a look.** A surviving attached minio blob necessarily belongs to a `WebuiUpload` with `copied: false` — an upload whose files were never copied into place. It is dormant now, but `copy_files_to_submissions_dir` ends in `update! files: []`, which enqueues a purge per blob, so it would raise the same `KeyError` the moment that upload ever completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)