### PR TITLE
Notice an upload whose files never arrived

### DIFF
--- a/app/jobs/copy_submission_files_job.rb
+++ b/app/jobs/copy_submission_files_job.rb
@@ -1,6 +1,23 @@
 class CopySubmissionFilesJob < ApplicationJob
   queue_as :default
 
+  # Until this has run, the blobs a direct upload made are the only copy of the
+  # submitter's files, and nothing else will come for them: there is no route
+  # that runs it again. So the ways a disk or a network lets us down are worth
+  # another go rather than a place in the failed list -- including the storage
+  # answering 503 while it restarts, and telling us an object is not there when
+  # a volume server has yet to catch up. Copying is idempotent: a directory
+  # already in place is left alone.
+  #
+  # The net is cast by where the trouble came from rather than by whether it
+  # will pass, so a full disk is tried five times too. Six minutes to reach the
+  # failed list is nothing against the day the sweep waits before asking after
+  # an upload, and everything else still fails at once, where it can be seen.
+  retry_on SystemCallError,                   wait: :polynomially_longer, attempts: 5
+  retry_on Seahorse::Client::NetworkingError, wait: :polynomially_longer, attempts: 5
+  retry_on Aws::Errors::ServiceError,         wait: :polynomially_longer, attempts: 5
+  retry_on ActiveStorage::FileNotFoundError,  wait: :polynomially_longer, attempts: 5
+
   def perform(upload)
     upload.via.copy_files_to_submissions_dir
   end

--- a/app/jobs/report_uncopied_uploads_job.rb
+++ b/app/jobs/report_uncopied_uploads_job.rb
@@ -1,0 +1,51 @@
+class ReportUncopiedUploadsJob < ApplicationJob
+  # An upload whose files never reached the submission directory. The submitter
+  # was told they sent them and the curator has nothing to open, and nothing
+  # says so: the copy runs once, and a failure leaves it in the failed list for
+  # somebody to notice.
+  class UncopiedUpload < StandardError; end
+
+  # Files that arrived without the blobs they came in being let go. Active
+  # Storage is a waiting room; these are sitting in it with nowhere to be.
+  class UnreleasedBlobs < StandardError; end
+
+  # Too many at once is not a story about uploads. Said as one, so that a
+  # submissions directory that is not where we left it does not arrive as
+  # thousands of separate alarms.
+  class NothingArrived < StandardError; end
+
+  # Long enough that an upload still on its way is not mistaken for one that
+  # will never arrive.
+  GRACE = 1.day
+
+  # Beyond this, they are not being reported one at a time.
+  INDIVIDUALLY = 20
+
+  queue_as :default
+
+  def perform
+    uploads = Upload.includes(:submission).where(created_at: ..GRACE.ago).to_a
+
+    uncopied  = uploads.reject { _1.files_dir.exist? }
+    unclaimed = uploads.select { _1.webui_upload? && _1.files_dir.exist? && !_1.via.copied? }
+
+    if uncopied.size > INDIVIDUALLY
+      report NothingArrived.new("#{uncopied.size} of #{uploads.size} uploads have no directory, which is more about where we are looking than about them")
+    else
+      uncopied.each  { report UncopiedUpload.new("the files of #{name_of(_1)} never reached the submission") }
+      unclaimed.each { report UnreleasedBlobs.new("the files of #{name_of(_1)} arrived, but the blobs they came in were never let go") }
+    end
+  end
+
+  private
+
+  # Named the same way every night, so that each upload is one thing to answer
+  # for rather than a sentence that reads differently as they come and go.
+  def name_of(upload)
+    "upload #{upload.submission.mass_id}/#{upload.files_dir_name}"
+  end
+
+  def report(error)
+    Rails.error.report error, handled: true
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -14,5 +14,13 @@ production: &production
     priority: 10
     schedule: at 4:30am every day
 
+  # Not a sweep: a look for uploads whose files never arrived. Until the copy
+  # has run, the blobs are the only copy the submitter has left with us, and
+  # nothing else says it has not.
+  report_uncopied_uploads:
+    class: ReportUncopiedUploadsJob
+    priority: 10
+    schedule: at 5am every day
+
 staging:
   <<: *production

--- a/test/fixtures/webui_uploads.yml
+++ b/test/fixtures/webui_uploads.yml
@@ -1,2 +1,2 @@
 one:
-  copied: false
+  copied: true

--- a/test/jobs/copy_submission_files_job_test.rb
+++ b/test/jobs/copy_submission_files_job_test.rb
@@ -32,6 +32,19 @@ class CopySubmissionFilesJobTest < ActiveJob::TestCase
     )
   end
 
+  # The job reads the upload back from the database, so the blob it downloads
+  # is not one this test holds: stand in for all of them. Attachment delegates
+  # what it does not have to its blob, which is where download really lives.
+  def stub_download(replacement)
+    original = ActiveStorage::Blob.instance_method(:download)
+
+    ActiveStorage::Blob.define_method(:download, &replacement)
+
+    yield
+  ensure
+    ActiveStorage::Blob.define_method(:download, original)
+  end
+
   test 'copies files to submissions dir' do
     CopySubmissionFilesJob.perform_now @upload
 
@@ -56,6 +69,60 @@ class CopySubmissionFilesJobTest < ActiveJob::TestCase
     end
 
     assert_equal ['example.ann'], Dir.glob('*', base: upload.files_dir)
+  end
+
+  test 'a copy that broke down on the way is tried again' do
+    extraction = dfast_extractions(:alice_dfast_extraction)
+
+    extraction.working_dir.mkpath
+    extraction.files.create!(name: 'example.ann', dfast_job_id: 'job-1', parsing: false)
+    extraction.working_dir.join('example.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+
+    upload   = Upload.create!(submission: @submission, via: DfastUpload.new(extraction:), created_at: '2022-05-06 07:08:09')
+    attempts = 0
+
+    cp = ->(*args) {
+      attempts += 1
+
+      raise Errno::EIO if attempts == 1
+
+      FileUtils.copy(*args)
+    }
+
+    # Until this has run the blobs are the only copy of what the submitter
+    # sent, and nothing else comes for them: a disk that hiccups once must not
+    # be the end of it.
+    perform_enqueued_jobs do
+      FileUtils.stub :cp, cp do
+        CopySubmissionFilesJob.perform_later upload
+      end
+    end
+
+    assert_equal 2, attempts
+    assert_equal ['example.ann'], Dir.glob('*', base: upload.files_dir)
+  end
+
+  test 'a download the storage could not answer is tried again' do
+    attempts = 0
+
+    # What SeaweedFS answering while it restarts arrives as -- neither a
+    # SystemCallError nor a networking error. Named here as well as in the job,
+    # so that the job failing to load for want of the constant is a test
+    # failure rather than every upload breaking.
+    stub_download ->(&block) {
+      attempts += 1
+
+      raise Aws::S3::Errors::ServiceUnavailable.new(nil, 'try later') if attempts == 1
+
+      block.call "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+    } do
+      perform_enqueued_jobs do
+        CopySubmissionFilesJob.perform_later @upload
+      end
+    end
+
+    assert_equal 2, attempts
+    assert_equal ['example.ann'], Dir.glob('*', base: @upload.files_dir)
   end
 
   test 'trim whitespace from contact fields in annotation files' do

--- a/test/jobs/report_uncopied_uploads_job_test.rb
+++ b/test/jobs/report_uncopied_uploads_job_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class ReportUncopiedUploadsJobTest < ActiveJob::TestCase
+  setup do
+    @submission = submissions(:alice_submission)
+
+    # The fixture upload is one of these too, so put its files in place and
+    # leave each test to introduce the one it is about.
+    uploads(:alice_upload).files_dir.mkpath
+  end
+
+  def webui_upload(created_at:, arrived: true, copied: true)
+    @submission.uploads.create!(via: WebuiUpload.new(copied:), created_at:).tap {
+      _1.files_dir.mkpath if arrived
+    }
+  end
+
+  def extraction_upload(created_at:, arrived: true)
+    extraction = dfast_extractions(:alice_dfast_extraction)
+
+    @submission.uploads.create!(via: DfastUpload.new(extraction:), created_at:).tap {
+      _1.files_dir.mkpath if arrived
+    }
+  end
+
+  def reports(klass, &)
+    capture_error_reports(klass, &).map { _1.error.message }
+  end
+
+  test 'an upload whose files never arrived is reported' do
+    stuck = webui_upload(created_at: 2.days.ago, arrived: false)
+
+    # It sat like this for two years and ten months once, and nothing said so.
+    assert_equal ["the files of upload #{@submission.mass_id}/#{stuck.files_dir_name} never reached the submission"],
+                 reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'an upload that came from an extraction is asked after the same way' do
+    stuck = extraction_upload(created_at: 2.days.ago, arrived: false)
+
+    assert_equal ["the files of upload #{@submission.mass_id}/#{stuck.files_dir_name} never reached the submission"],
+                 reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'each one is named on its own, rather than gathered into a sentence' do
+    first  = webui_upload(created_at: 2.days.ago, arrived: false)
+    second = webui_upload(created_at: 3.days.ago, arrived: false)
+
+    # One thing to answer for apiece: a sentence listing both would be a
+    # different sentence the day one of them is dealt with.
+    assert_equal 2, reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }.size
+
+    assert_equal [first, second].map { "the files of upload #{@submission.mass_id}/#{_1.files_dir_name} never reached the submission" }.sort,
+                 reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }.sort
+  end
+
+  test 'files that arrived without their blobs being let go' do
+    upload = webui_upload(created_at: 2.days.ago, copied: false)
+
+    # The waiting room is meant to empty as the files leave it. This one did
+    # not, and no sweep reaches a blob that is still attached.
+    assert_equal ["the files of upload #{@submission.mass_id}/#{upload.files_dir_name} arrived, but the blobs they came in were never let go"],
+                 reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'an upload whose files are in place is not reported' do
+    webui_upload created_at: 2.days.ago
+
+    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+    assert_empty reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'an upload still on its way is given time to arrive' do
+    webui_upload created_at: 1.hour.ago, arrived: false
+
+    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'nothing at all arriving is one thing to say, not thousands' do
+    (ReportUncopiedUploadsJob::INDIVIDUALLY + 1).times {|i|
+      webui_upload created_at: (2 + i).days.ago, arrived: false
+    }
+
+    # A submissions directory that is not where we left it would otherwise
+    # arrive as an alarm for every upload ever made.
+    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+
+    assert_match(/have no directory/,
+                 reports(ReportUncopiedUploadsJob::NothingArrived) { ReportUncopiedUploadsJob.perform_now }.sole)
+  end
+end


### PR DESCRIPTION
Active Storage is a waiting room. A submitter's files land there, `CopySubmissionFilesJob` moves them into the submission directory, and `update! copied: true, files: []` lets the blobs go. What the application could not see is a file that never leaves.

An upload whose copy never ran looks exactly like one whose copy has not run yet — `Upload#file_names` answers from the blobs in both cases. So the submitter is told they sent their files, the curator opens a directory that is not there, and nothing anywhere says otherwise. NSUB001289's upload 1853 sat like that from **2023-10-23 until MinIO was decommissioned in March**, at which point the files became unrecoverable. The blobs were healthy that whole time; re-running the copy would have worked on any of ~880 days. Nobody looked.

Two commits, one for each half of that.

## Another go

`ApplicationJob` has every `retry_on` commented out, so one failure parks the job in `solid_queue_failed_executions` and that is the end of it. `CopySubmissionFilesJob` now retries what a disk or a network does to you:

- `SystemCallError` — the whole `Errno::*` family
- `Seahorse::Client::NetworkingError` — connection-level S3 failures
- `Aws::Errors::ServiceError` — **the one that mattered**. SeaweedFS answering 503 while it restarts is neither of the above; aws-sdk's own retry gives up after ~2 seconds, which is shorter than any restart, and the error then escapes as a plain `RuntimeError` descendant.
- `ActiveStorage::FileNotFoundError` — a volume server that has yet to catch up reports a missing object exactly like one that is really gone. Five attempts cost nothing; if it is really gone it still fails, and the sweep below picks it up the next day.

Copying has been idempotent since #1649 made an existing directory be left alone, so there is nothing to undo between attempts. I verified that by experiment rather than by reading: failing on the second of two files and retrying gives four downloads, both files in place, `copied: true`, no attachments left, no `.work` leftovers, and the annotation trim applied exactly once.

The net is cast by where the trouble came from, not by whether it will pass, so a full disk is tried five times too — six minutes to reach the failed list, against a day before the sweep asks after it. Everything else still fails at once.

## Nightly look

`ReportUncopiedUploadsJob` asks, of every upload older than a day, whether its directory is there. That is the right question for all four ways of uploading: the directory is renamed into place in one go at the end of the copy, so its existence *is* the arrival.

- **Each is named on its own**, not gathered into a sentence. One Sentry issue per stuck upload, individually resolvable, whose identity does not change as others come and go. A single message listing them all would become a different message — and a different issue — the moment one was dealt with.
- **Beyond twenty, it is said once instead.** That many at a time is a story about where we are looking, not about the uploads: a submissions directory that is not where we left it would otherwise arrive as an alarm for every upload ever made.
- **The other half is asked after too.** If the process dies between the rename and `update! copied: true, files: []`, the files are in place but the blobs stay *attached* — and `PurgeUnattachedUploadsJob` only scans unattached blobs, so nothing ever reclaims them. That is a permanent occupant of the waiting room, and it now reports as one.

## Note

`test/fixtures/webui_uploads.yml` flips to `copied: true`. The fixture upload was itself an example of what this job looks for, which is a good sign for the check and a poor baseline for the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)