### PR TITLE
Let every upload say for itself that its files were handed over

### DIFF
--- a/app/jobs/report_uncopied_uploads_job.rb
+++ b/app/jobs/report_uncopied_uploads_job.rb
@@ -5,39 +5,105 @@ class ReportUncopiedUploadsJob < ApplicationJob
   # somebody to notice.
   class UncopiedUpload < StandardError; end
 
+  # Files that were copied and are not where they were put -- with the
+  # submission they belong to still standing, or copied recently enough that
+  # nobody can have finished with it. Either way this is the ground they were
+  # standing on rather than anything about the upload.
+  class VanishedFiles < StandardError; end
+
   # Files that arrived without the blobs they came in being let go. Active
-  # Storage is a waiting room; these are sitting in it with nowhere to be.
+  # Storage is a waiting room; these are sitting in it with nowhere to be, and
+  # no sweep reaches them -- a sweep takes the blobs nothing is attached to.
   class UnreleasedBlobs < StandardError; end
 
-  # Too many at once is not a story about uploads. Said as one, so that a
-  # submissions directory that is not where we left it does not arrive as
-  # thousands of separate alarms.
-  class NothingArrived < StandardError; end
+  # More of one of those than anybody is going to work through by hand. Said
+  # without the number in it, so that it stays one thing to answer for however
+  # far it spreads.
+  class TooMany < StandardError; end
 
   # Long enough that an upload still on its way is not mistaken for one that
   # will never arrive.
   GRACE = 1.day
 
-  # Beyond this, they are not being reported one at a time.
+  # How recently the copy has to have happened for the directory still being
+  # there to be something we can insist on. Curators tidy away the submissions
+  # they have dealt with, and being dealt with takes a while; nobody tidies
+  # away this week's. So a directory gone from under a fresh copy is the
+  # filesystem, and one gone from under an old copy is somebody's housekeeping.
+  FRESH = 30.days
+
+  # Named one at a time up to here, and counted past it.
   INDIVIDUALLY = 20
 
   queue_as :default
 
   def perform
-    uploads = Upload.includes(:submission).where(created_at: ..GRACE.ago).to_a
+    # Oldest first, so that the ones named when there are more than can be
+    # named keep their place: an upload nobody has got to yet is the same thing
+    # to answer for tomorrow, not a fresh one because the order came up
+    # differently.
+    uploads = Upload.includes(:submission).where(created_at: ..GRACE.ago).order(:created_at).to_a
 
-    uncopied  = uploads.reject { _1.files_dir.exist? }
-    unclaimed = uploads.select { _1.webui_upload? && _1.files_dir.exist? && !_1.via.copied? }
+    report_each uploads.reject { _1.copied? }, UncopiedUpload do
+      "the files of #{name_of(_1)} never reached the submission"
+    end
 
-    if uncopied.size > INDIVIDUALLY
-      report NothingArrived.new("#{uncopied.size} of #{uploads.size} uploads have no directory, which is more about where we are looking than about them")
-    else
-      uncopied.each  { report UncopiedUpload.new("the files of #{name_of(_1)} never reached the submission") }
-      unclaimed.each { report UnreleasedBlobs.new("the files of #{name_of(_1)} arrived, but the blobs they came in were never let go") }
+    report_each vanished(uploads), VanishedFiles do
+      "the files of #{name_of(_1)} were copied, and are not where they were put"
+    end
+
+    report_each unclaimed(uploads), UnreleasedBlobs do
+      "the files of #{name_of(_1)} arrived, but the blobs they came in were never let go"
     end
   end
 
   private
+
+  # Naming stops being useful long before it stops being possible, so past a
+  # point they are counted instead -- counted rather than dropped, and each kind
+  # counted on its own. A pile of one of them is no reason to go quiet about the
+  # single upload of another that somebody could still do something for.
+  #
+  # The count goes first. What is behind this queues the events and drops what
+  # it cannot keep up with, and of everything said about a night like that, the
+  # one line saying how big it is has to be the one that gets through.
+  def report_each(candidates, error_class)
+    if candidates.size > INDIVIDUALLY
+      report TooMany.new("more uploads with this the matter with them than anybody will take one at a time: #{error_class.name.demodulize}"),
+             count: candidates.size
+    end
+
+    candidates.first(INDIVIDUALLY).each { report error_class.new(yield(_1)) }
+  end
+
+  # Copied, and the files are not there. Told apart from a curator having
+  # tidied the submission away by what they leave: they take the directory the
+  # whole submission lives in, and they only take submissions they have
+  # finished with, which takes a while. So a submission still standing without
+  # its files is the ground moving whenever it happened, and one that is gone
+  # entirely is only worth asking about while it is too recent to have been
+  # anybody's housekeeping.
+  def vanished(uploads)
+    uploads.select {
+      next false unless _1.copied_at? && !_1.files_dir.exist?
+
+      _1.submission.root_dir.exist? || _1.copied_at.after?(FRESH.ago)
+    }
+  end
+
+  # Copied, and still holding the blobs it was copied from. Asked of the
+  # attachments themselves, in one query rather than one apiece: a flag set
+  # alongside the purge would say the blobs had been let go however far the
+  # purge actually got.
+  #
+  # Only a direct upload has any. The ids are of webui_uploads rows, and every
+  # other way of arriving numbers its own table from one, so without asking
+  # which way this arrived the two would be read as the same upload.
+  def unclaimed(uploads)
+    still_held = ActiveStorage::Attachment.where(record_type: 'WebuiUpload', name: 'files').pluck(:record_id).to_set
+
+    uploads.select { _1.webui_upload? && still_held.include?(_1.via_id) && _1.copied? }
+  end
 
   # Named the same way every night, so that each upload is one thing to answer
   # for rather than a sentence that reads differently as they come and go.
@@ -45,7 +111,7 @@ class ReportUncopiedUploadsJob < ApplicationJob
     "upload #{upload.submission.mass_id}/#{upload.files_dir_name}"
   end
 
-  def report(error)
-    Rails.error.report error, handled: true
+  def report(error, **context)
+    Rails.error.report error, handled: true, context:
   end
 end

--- a/app/models/concerns/upload_via.rb
+++ b/app/models/concerns/upload_via.rb
@@ -17,31 +17,39 @@ module UploadVia
   # curator it is handed to, nor by the submitter, who is told what the upload
   # holds from where it came from until it is there.
   #
-  # That move is also what records the copy: a job asked to do it again finds
-  # the directory and leaves it be. Without this a retry renamed onto a full
-  # directory, which fails with ENOTEMPTY however often it is tried.
+  # A job asked to do it again finds the directory and leaves it be. Without
+  # this a retry renamed onto a full directory, which fails with ENOTEMPTY
+  # however often it is tried.
+  #
+  # The handover is written down here, where every way of arriving passes
+  # through -- including the way through that skips the move, so that an upload
+  # whose copy landed but whose job died on the way out is put right by being
+  # asked again.
   def stage_files
-    return if upload.files_dir.exist?
+    unless upload.files_dir.exist?
+      # Named after the upload rather than the directory it is bound for, which
+      # is settled while the upload is being made: this runs long afterwards,
+      # and asks nothing of what it was settled to be.
+      work = submission.root_dir.join("../.work/#{submission.mass_id}-#{upload.id}")
+      work.mkpath
 
-    # Named after the upload rather than the directory it is bound for, which
-    # is settled while the upload is being made: this runs long afterwards, and
-    # asks nothing of what it was settled to be.
-    work = submission.root_dir.join("../.work/#{submission.mass_id}-#{upload.id}")
-    work.mkpath
+      begin
+        yield work
 
-    begin
-      yield work
+        trim_annotation_fields! work
 
-      trim_annotation_fields! work
-
-      upload.files_dir.dirname.mkpath
-      work.rename upload.files_dir
-    ensure
-      # The move takes this with it, so anything left is from an attempt that
-      # broke down. Clear it out: it would otherwise sit here for good, and the
-      # next attempt would move whatever it holds along with its own files.
-      work.rmtree if work.exist?
+        upload.files_dir.dirname.mkpath
+        work.rename upload.files_dir
+      ensure
+        # The move takes this with it, so anything left is from an attempt that
+        # broke down. Clear it out: it would otherwise sit here for good, and
+        # the next attempt would move whatever it holds along with its own
+        # files.
+        work.rmtree if work.exist?
+      end
     end
+
+    upload.update! copied_at: Time.current unless upload.copied_at?
   end
 
   def trim_annotation_fields!(dir)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -21,10 +21,14 @@ class Submission < ApplicationRecord
     last ? last.mass_id.delete_prefix('NSUB').to_i : 0
   end
 
-  def root_dir
-    dir = Rails.application.config_for(:app).submissions_dir!
+  # Read once. config_for parses the file afresh on every call, and the nightly
+  # look over every upload ever made asks each of them where its files are.
+  def self.submissions_dir
+    @submissions_dir ||= Pathname.new(Rails.application.config_for(:app).submissions_dir!)
+  end
 
-    Pathname.new(dir).join(mass_id)
+  def root_dir
+    Submission.submissions_dir.join(mass_id)
   end
 
   def upload_disabled?

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -35,8 +35,15 @@ class Upload < ApplicationRecord
   # background, in one move, so until that has happened the names are known
   # only where they came from.
   #
+  # Everything in the directory, rather than everything with a dot in its name,
+  # and in an order rather than the one the directory happens to hold them in.
+  # Only the staging writes there and it writes the files as they were sent, so
+  # what is in there is what the upload consists of -- extension or no, leading
+  # dot or no.
   def file_names
-    Dir.glob('*.*', base: files_dir).presence || via.source_file_names
+    names = files_dir.exist? ? Dir.children(files_dir).sort : []
+
+    names.presence || via.source_file_names
   end
 
   def files_dir

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -34,12 +34,31 @@ class Upload < ApplicationRecord
   # The files this upload consists of. They are copied into place in the
   # background, in one move, so until that has happened the names are known
   # only where they came from.
+  #
   def file_names
     Dir.glob('*.*', base: files_dir).presence || via.source_file_names
   end
 
   def files_dir
     submission.root_dir.join(files_dir_name)
+  end
+
+  # Whether the files were handed over. The directory in place is the plain
+  # evidence, but it sits on a filesystem curators work on too, and one tidied
+  # away long after the submission was dealt with says nothing about whether it
+  # was ever filled. So the copy says so itself as it lands, and that no later
+  # tidying can take back.
+  #
+  # The directory still counts, for the uploads that were copied before anything
+  # was written down.
+  #
+  # The trade: files that were copied and then lost -- a restore that came back
+  # short, a volume mounted somewhere else -- read as handed over, because from
+  # here that is indistinguishable from a curator having tidied them away. What
+  # tells those apart is how long ago the copy was, and the nightly report asks
+  # that of the recent ones separately.
+  def copied?
+    copied_at? || files_dir.exist?
   end
 
   def via_ident

--- a/app/models/webui_upload.rb
+++ b/app/models/webui_upload.rb
@@ -1,6 +1,13 @@
 class WebuiUpload < ApplicationRecord
   include UploadVia
 
+  # Said two things at once and could only be seen from here, so both moved:
+  # whether the files were copied is on the upload now, and whether the blobs
+  # were let go is asked of the attachments. Ignored rather than dropped, so
+  # that the containers still serving during the deploy that stops writing it
+  # are not inserting a column this one has taken away.
+  self.ignored_columns = %i[copied]
+
   has_many_attached :files
 
   # The signed IDs come from a direct upload this submitter just made, so an
@@ -16,8 +23,6 @@ class WebuiUpload < ApplicationRecord
   end
 
   def copy_files_to_submissions_dir
-    return if copied?
-
     stage_files do |work|
       files.each do |attachment|
         work.join(attachment.filename.to_s).open 'wb' do |f|
@@ -28,7 +33,13 @@ class WebuiUpload < ApplicationRecord
       end
     end
 
-    update! copied: true, files: []
+    # Active Storage is where the submitter's files wait to be fetched, not
+    # where they are kept: with them in the submission directory it has nothing
+    # left to hold. Here and now rather than left to a job of its own, so that
+    # a storage which will not let go is the copy's failure, retried with it --
+    # a purge that quietly gave up leaves blobs no sweep can reach, since a
+    # sweep only takes the ones nothing is attached to.
+    files.purge
   end
 
   def source_file_names

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,4 +7,10 @@ Sentry.init do |config|
   # -- ours, and the worker thread errors Solid Queue reports for us -- is
   # written down nowhere and read by nobody.
   config.rails.register_error_subscriber = true
+
+  # The queue behind the sending threads discards silently once it is full, and
+  # thirty is not many: the nightly look at uploads posts a burst of everything
+  # it found in one go, and a night when it finds a lot is the night the last
+  # of it matters most.
+  config.background_worker_max_queue = 100
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,9 +1,9 @@
-production: &production
-  # Both sweep up after what a submitter left behind: the files an extraction
-  # gathered, and the blobs a direct upload made for an application that was
-  # never sent. Overnight, when neither is likely to be in the middle of use,
-  # and behind everything else in the queue -- a backlog of them must not keep
-  # a submitter's own upload waiting.
+# Both sweep up after what a submitter left behind: the files an extraction
+# gathered, and the blobs a direct upload made for an application that was never
+# sent. Overnight, when neither is likely to be in the middle of use, and behind
+# everything else in the queue -- a backlog of them must not keep a submitter's
+# own upload waiting.
+sweeps: &sweeps
   purge_extractions:
     class: PurgeExtractionsJob
     priority: 10
@@ -14,13 +14,20 @@ production: &production
     priority: 10
     schedule: at 4:30am every day
 
+production:
+  <<: *sweeps
+
   # Not a sweep: a look for uploads whose files never arrived. Until the copy
   # has run, the blobs are the only copy the submitter has left with us, and
   # nothing else says it has not.
+  #
+  # Only here. Staging is where half-finished work is left lying, and an upload
+  # abandoned there is nobody's to answer for: reported, it would be the same
+  # few names every morning, in the same place the ones that matter arrive.
   report_uncopied_uploads:
     class: ReportUncopiedUploadsJob
     priority: 10
     schedule: at 5am every day
 
 staging:
-  <<: *production
+  <<: *sweeps

--- a/db/migrate/20260823143111_record_when_an_upload_was_copied.rb
+++ b/db/migrate/20260823143111_record_when_an_upload_was_copied.rb
@@ -1,0 +1,66 @@
+class RecordWhenAnUploadWasCopied < ActiveRecord::Migration[8.1]
+  # Whether the files had been handed over was recorded on webui_uploads, where
+  # only a direct upload could see it. An upload gathered from an extraction had
+  # nothing to go on but its directory, and that directory sits on a filesystem
+  # curators work on too: one tidied away after the submission was dealt with
+  # left the nightly look for uploads that never arrived naming it every
+  # morning, for good.
+  #
+  # So the record moves to the upload itself, where every way of arriving passes
+  # through. What it said on webui_uploads was really two things at once -- the
+  # files were copied, and the blobs were let go -- and the second is now asked
+  # of the attachments, which answer it whether or not the purge got that far.
+  #
+  # webui_uploads.copied is left standing. Nothing reads it from here, but the
+  # containers still serving while this runs do, and every submission made in
+  # that window inserts a row naming it. It goes in a deploy of its own -- and
+  # that one runs this same backfill again first: a copy those containers
+  # finished after this ran set the old flag and nothing else, so the upload it
+  # belongs to is still sitting here with no copied_at.
+  def up
+    add_column :uploads, :copied_at, :datetime
+
+    execute <<~SQL.squish
+      UPDATE uploads SET copied_at = webui_uploads.updated_at
+      FROM webui_uploads
+      WHERE uploads.via_type = 'WebuiUpload'
+        AND uploads.via_id = webui_uploads.id
+        AND webui_uploads.copied
+    SQL
+
+    backfill_from_disk
+  end
+
+  def down
+    remove_column :uploads, :copied_at
+  end
+
+  private
+
+  # Every other way of arriving says so only by having a directory. Read them
+  # once, here, rather than leaving each of them to be judged by a filesystem
+  # for the rest of its life. Nothing to read is not a reason to declare them
+  # all uncopied: the directory is still the fallback, so they lose nothing.
+  def backfill_from_disk
+    root = Pathname.new(Rails.application.config_for(:app).submissions_dir!)
+
+    return unless root.exist?
+
+    rows = select_all(<<~SQL.squish)
+      SELECT uploads.id, uploads.files_dir_name, submissions.mass_id
+      FROM uploads
+      JOIN submissions ON submissions.id = uploads.submission_id
+      WHERE uploads.copied_at IS NULL
+    SQL
+
+    copied = rows.filter_map {
+      Integer(_1['id']) if root.join(_1['mass_id'], _1['files_dir_name']).exist?
+    }
+
+    copied.each_slice(1_000) do |slice|
+      execute "UPDATE uploads SET copied_at = updated_at WHERE id IN (#{slice.join(', ')})"
+    end
+
+    say "read #{copied.size} uploads off the disk", true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_033644) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_143111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -166,6 +166,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_033644) do
   end
 
   create_table "uploads", force: :cascade do |t|
+    t.datetime "copied_at"
     t.datetime "created_at", null: false
     t.string "files_dir_name", null: false
     t.bigint "submission_id", null: false

--- a/test/fixtures/webui_uploads.yml
+++ b/test/fixtures/webui_uploads.yml
@@ -1,2 +1,1 @@
-one:
-  copied: true
+one: {}

--- a/test/jobs/copy_submission_files_job_test.rb
+++ b/test/jobs/copy_submission_files_job_test.rb
@@ -54,6 +54,30 @@ class CopySubmissionFilesJobTest < ActiveJob::TestCase
     assert_equal 'file',      dir.join('example.ann').ftype
   end
 
+  test 'the blobs are let go once the files are in place' do
+    CopySubmissionFilesJob.perform_now @upload
+
+    # Active Storage is the waiting room, not the shelf. Nothing else comes for
+    # these: a sweep only takes the blobs nothing is attached to.
+    assert_not @upload.via.reload.files.attached?
+    assert_predicate @upload.reload, :copied_at
+  end
+
+  test 'a copy that landed but never let its blobs go is put right by being asked again' do
+    # What a crash between the move and the purge leaves behind, which is how
+    # two uploads sat for five months: the files were handed over, and the
+    # blobs they came in stayed attached where no sweep could reach them.
+    @upload.files_dir.mkpath
+    @upload.files_dir.join('example.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+
+    CopySubmissionFilesJob.perform_now @upload
+
+    assert_not @upload.via.reload.files.attached?
+    assert_predicate @upload.reload, :copied_at
+
+    assert_equal "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n", @upload.files_dir.join('example.ann').read
+  end
+
   test 'running again over files already in place' do
     extraction = dfast_extractions(:alice_dfast_extraction)
 
@@ -69,6 +93,24 @@ class CopySubmissionFilesJobTest < ActiveJob::TestCase
     end
 
     assert_equal ['example.ann'], Dir.glob('*', base: upload.files_dir)
+
+    # Written down here as much as for a direct upload: the staging both go
+    # through is the one place that knows the files have landed.
+    assert_predicate upload.reload, :copied_at
+  end
+
+  test 'when the files landed is not moved by asking again' do
+    CopySubmissionFilesJob.perform_now @upload
+
+    landed = @upload.reload.copied_at
+
+    travel 1.day do
+      CopySubmissionFilesJob.perform_now @upload
+    end
+
+    # It says when the submitter's files reached the submission, which is not
+    # something a later run has anything new to say about.
+    assert_equal landed, @upload.reload.copied_at
   end
 
   test 'a copy that broke down on the way is tried again' do

--- a/test/jobs/report_uncopied_uploads_job_test.rb
+++ b/test/jobs/report_uncopied_uploads_job_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+using TmpUploadedFile
+
 class ReportUncopiedUploadsJobTest < ActiveJob::TestCase
   setup do
     @submission = submissions(:alice_submission)
@@ -9,16 +11,45 @@ class ReportUncopiedUploadsJobTest < ActiveJob::TestCase
     uploads(:alice_upload).files_dir.mkpath
   end
 
-  def webui_upload(created_at:, arrived: true, copied: true)
-    @submission.uploads.create!(via: WebuiUpload.new(copied:), created_at:).tap {
+  # An upload that never landed was never written down as copied either, so let
+  # one follow the other unless a test is about them disagreeing. `holding` is
+  # the blobs it came in still being attached, which a copy that ran to the end
+  # would have let go of.
+  def webui_upload(created_at:, arrived: true, copied: arrived, holding: false, submission: @submission)
+    via = WebuiUpload.new
+
+    via.files.attach Rack::Test::UploadedFile.tmp('example.ann') if holding
+
+    submission.uploads.create!(via:, created_at:, copied_at: (created_at if copied)).tap {
       _1.files_dir.mkpath if arrived
     }
   end
 
-  def extraction_upload(created_at:, arrived: true)
+  # One nobody has left a directory for, the way a submission that has been
+  # dealt with and cleared away is left: the whole thing gone, not one upload's
+  # files taken out of it.
+  def cleared_submission
+    Submission.create!(
+      mass_id:        'NSUB000042',
+      user:           users(:alice),
+      tpa:            false,
+      entries_count:  1,
+      sequencer:      'ngs',
+      data_type:      'wgs',
+      email_language: 'en',
+
+      contact_person: ContactPerson.new(
+        email:       'alice+contact@example.com',
+        full_name:   'Alice Liddell',
+        affiliation: 'Wonderland Inc.'
+      )
+    )
+  end
+
+  def extraction_upload(created_at:, arrived: true, copied: arrived)
     extraction = dfast_extractions(:alice_dfast_extraction)
 
-    @submission.uploads.create!(via: DfastUpload.new(extraction:), created_at:).tap {
+    @submission.uploads.create!(via: DfastUpload.new(extraction:), created_at:, copied_at: (created_at if copied)).tap {
       _1.files_dir.mkpath if arrived
     }
   end
@@ -55,7 +86,7 @@ class ReportUncopiedUploadsJobTest < ActiveJob::TestCase
   end
 
   test 'files that arrived without their blobs being let go' do
-    upload = webui_upload(created_at: 2.days.ago, copied: false)
+    upload = webui_upload(created_at: 2.days.ago, holding: true)
 
     # The waiting room is meant to empty as the files leave it. This one did
     # not, and no sweep reaches a blob that is still attached.
@@ -63,8 +94,55 @@ class ReportUncopiedUploadsJobTest < ActiveJob::TestCase
                  reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
   end
 
+  test 'files that arrived before the copy could be written down, still holding their blobs' do
+    upload = webui_upload(created_at: 2.days.ago, copied: false, holding: true)
+
+    # Two uploads sat in exactly this state for five months: the move had
+    # happened, and everything after it -- the record, the purge, the mail, the
+    # curator sheet -- died with the job. The directory is all the copy left
+    # behind, so it has to be enough to know the blobs are owed nothing.
+    assert_equal ["the files of upload #{@submission.mass_id}/#{upload.files_dir_name} arrived, but the blobs they came in were never let go"],
+                 reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
+
+    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'an upload whose directory was tidied away long afterwards is not reported' do
+    webui_upload      created_at: 2.days.ago, arrived: false, copied: true
+    extraction_upload created_at: 2.days.ago, arrived: false, copied: true
+
+    # Curators work on this filesystem too, and a submission dealt with a year
+    # ago may not be sitting where it was left. The copy said so as it landed,
+    # and that stands however the directory is treated afterwards -- for every
+    # way of arriving, not only the one that happened to keep a flag.
+    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+    assert_empty reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'an upload that never landed is named for that, not for its blobs' do
+    stuck = webui_upload(created_at: 2.days.ago, arrived: false, holding: true)
+
+    # It is still holding them, but that is not the thing wrong with it: the
+    # blobs are the only copy left of what the submitter sent.
+    assert_equal ["the files of upload #{@submission.mass_id}/#{stuck.files_dir_name} never reached the submission"],
+                 reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+
+    assert_empty reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'an upload copied before any of this was written down is not reported' do
+    webui_upload      created_at: 2.days.ago, copied: false
+    extraction_upload created_at: 2.days.ago, copied: false
+
+    # Years of uploads have nothing but their directory to show for themselves,
+    # and they were all handed over. The record only starts from here.
+    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+    assert_empty reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
+  end
+
   test 'an upload whose files are in place is not reported' do
-    webui_upload created_at: 2.days.ago
+    webui_upload      created_at: 2.days.ago
+    extraction_upload created_at: 2.days.ago
 
     assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
     assert_empty reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
@@ -76,16 +154,119 @@ class ReportUncopiedUploadsJobTest < ActiveJob::TestCase
     assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
   end
 
-  test 'nothing at all arriving is one thing to say, not thousands' do
+  test 'more of them than anybody will take one at a time are named up to a point, then counted' do
     (ReportUncopiedUploadsJob::INDIVIDUALLY + 1).times {|i|
       webui_upload created_at: (2 + i).days.ago, arrived: false
     }
 
-    # A submissions directory that is not where we left it would otherwise
-    # arrive as an alarm for every upload ever made.
-    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+    # Counted rather than dropped, and the count is not in the sentence: a pile
+    # that grows overnight is the same thing to answer for, not a new one.
+    assert_equal ReportUncopiedUploadsJob::INDIVIDUALLY,
+                 reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }.size
 
-    assert_match(/have no directory/,
-                 reports(ReportUncopiedUploadsJob::NothingArrived) { ReportUncopiedUploadsJob.perform_now }.sole)
+    too_many = capture_error_reports(ReportUncopiedUploadsJob::TooMany) { ReportUncopiedUploadsJob.perform_now }.sole
+
+    assert_match(/UncopiedUpload/, too_many.error.message)
+    assert_equal ReportUncopiedUploadsJob::INDIVIDUALLY + 1, too_many.context.fetch(:count)
+  end
+
+  test 'how many there are is said before any of them are named' do
+    (ReportUncopiedUploadsJob::INDIVIDUALLY + 1).times {|i|
+      webui_upload created_at: (2 + i).days.ago, arrived: false
+    }
+
+    said = capture_error_reports { ReportUncopiedUploadsJob.perform_now }.map { _1.error.class }
+
+    # What carries these away queues them and drops what it cannot keep up
+    # with. On the night there is a lot to say, the line saying how much has to
+    # be the one that gets out.
+    assert_equal ReportUncopiedUploadsJob::TooMany, said.first
+  end
+
+  test 'the oldest are the ones named when there are more than will be named' do
+    oldest = (ReportUncopiedUploadsJob::INDIVIDUALLY + 1).times.map {|i|
+      webui_upload created_at: (2 + i).days.ago, arrived: false
+    }.last
+
+    # Whoever is working through these comes back to the same list tomorrow.
+    # An upload nobody has got to yet must not be crowded out by one that
+    # arrived after it.
+    named = reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+
+    assert_includes named, "the files of upload #{@submission.mass_id}/#{oldest.files_dir_name} never reached the submission"
+  end
+
+  test 'exactly as many as will be taken one at a time are all named' do
+    ReportUncopiedUploadsJob::INDIVIDUALLY.times {|i|
+      webui_upload created_at: (2 + i).days.ago, arrived: false
+    }
+
+    assert_equal ReportUncopiedUploadsJob::INDIVIDUALLY,
+                 reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }.size
+
+    assert_empty reports(ReportUncopiedUploadsJob::TooMany) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'files copied days ago that are not where they were put' do
+    upload = webui_upload(created_at: 3.days.ago, arrived: false, copied: true)
+
+    # Nobody has finished with a submission from this week, so nobody tidied it
+    # away. This is the ground the files were standing on.
+    assert_equal ["the files of upload #{@submission.mass_id}/#{upload.files_dir_name} were copied, and are not where they were put"],
+                 reports(ReportUncopiedUploadsJob::VanishedFiles) { ReportUncopiedUploadsJob.perform_now }
+
+    assert_empty reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'a submission cleared away days after the copy is too soon to be housekeeping' do
+    upload = webui_upload(created_at: 3.days.ago, arrived: false, copied: true, submission: cleared_submission)
+
+    # Nothing is left to point at, but nobody has finished with a submission
+    # from this week either, so its going is not somebody tidying up.
+    assert_equal ["the files of upload #{upload.submission.mass_id}/#{upload.files_dir_name} were copied, and are not where they were put"],
+                 reports(ReportUncopiedUploadsJob::VanishedFiles) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'a submission still standing without its files is the ground moving, however long ago' do
+    upload = webui_upload(created_at: 200.days.ago, arrived: false, copied: true)
+
+    # Curators clear away the whole submission, so one left standing with an
+    # upload's files taken out of it is not housekeeping, whatever its age.
+    assert_equal ["the files of upload #{@submission.mass_id}/#{upload.files_dir_name} were copied, and are not where they were put"],
+                 reports(ReportUncopiedUploadsJob::VanishedFiles) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'a history of submissions cleared away does not swallow the one that matters' do
+    cleared = cleared_submission
+
+    (ReportUncopiedUploadsJob::INDIVIDUALLY + 5).times {|i|
+      webui_upload created_at: (90 + i).days.ago, arrived: false, copied: true, submission: cleared
+    }
+
+    stuck = webui_upload(created_at: 2.days.ago, arrived: false)
+
+    # Curators only ever add to this pile, so anything counting it would sooner
+    # or later be answer enough on its own -- and from then on nothing would be
+    # named again, ever. What separates them is what is left behind and how
+    # long ago the copy was.
+    assert_equal ["the files of upload #{@submission.mass_id}/#{stuck.files_dir_name} never reached the submission"],
+                 reports(ReportUncopiedUploadsJob::UncopiedUpload) { ReportUncopiedUploadsJob.perform_now }
+
+    assert_empty reports(ReportUncopiedUploadsJob::VanishedFiles) { ReportUncopiedUploadsJob.perform_now }
+    assert_empty reports(ReportUncopiedUploadsJob::TooMany) { ReportUncopiedUploadsJob.perform_now }
+  end
+
+  test 'an upload that arrived another way is not read as a direct one holding blobs' do
+    holding = webui_upload(created_at: 2.days.ago, holding: true)
+
+    # The ids come from webui_uploads, and every other way of arriving numbers
+    # its own table from one. Two rows with the same id are not one upload.
+    imported = extraction_upload(created_at: 2.days.ago)
+
+    DfastUpload.where(id: imported.via_id).update_all(id: holding.via_id)
+    imported.update_column :via_id, holding.via_id
+
+    assert_equal ["the files of upload #{@submission.mass_id}/#{holding.files_dir_name} arrived, but the blobs they came in were never let go"],
+                 reports(ReportUncopiedUploadsJob::UnreleasedBlobs) { ReportUncopiedUploadsJob.perform_now }
   end
 end

--- a/test/models/upload_test.rb
+++ b/test/models/upload_test.rb
@@ -9,6 +9,38 @@ class UploadTest < ActiveSupport::TestCase
     @submission.uploads.create!(via: WebuiUpload.new, created_at: time)
   end
 
+  test 'a file the submitter named without an extension, or with a leading dot, is one of the files' do
+    upload = upload_at('2022-03-04 01:02:03')
+
+    upload.files_dir.mkpath
+
+    %w[sequence.ann README .hidden].each do |name|
+      upload.files_dir.join(name).write ''
+    end
+
+    # Submitters name their files, and nothing between here and the disk turns
+    # a name down. One left out of this list is one the submission never
+    # mentions again -- and if it were the only file, the list would fall back
+    # to the names the upload came in with, as though the copy had not run.
+    assert_equal %w[.hidden README sequence.ann], upload.file_names
+  end
+
+  test 'the files are listed in the same order before and after the copy' do
+    upload = upload_at('2022-03-04 01:02:03')
+
+    upload.files_dir.mkpath
+
+    # Written in an order the directory will not give them back in. The
+    # submitter is looking at this list while the copy runs, and it is drawn
+    # from the upload until then and from the disk afterwards: it must not
+    # rearrange itself under them the moment the files land.
+    %w[middle.ann alpha.ann zeta.ann beta.fasta gamma.tsv delta.txt].each do |name|
+      upload.files_dir.join(name).write ''
+    end
+
+    assert_equal %w[alpha.ann beta.fasta delta.txt gamma.tsv middle.ann zeta.ann], upload.file_names
+  end
+
   test 'build_via turns down a way of uploading we do not have' do
     ['sftp', '', nil].each do |via|
       assert_raises Upload::Malformed do

--- a/test/recurring_schedule_test.rb
+++ b/test/recurring_schedule_test.rb
@@ -6,9 +6,11 @@ class RecurringScheduleTest < ActiveSupport::TestCase
   # on a job that is not there or a schedule it cannot read -- and the Puma
   # plugin answers a supervisor that exits by signalling Puma itself. A typo
   # here does not lose a sweep; it takes the site down at boot.
-  test 'every environment schedules jobs that exist, at times that parse' do
-    config = ActiveSupport::ConfigurationFile.parse(Rails.root.join('config/recurring.yml')).deep_symbolize_keys
+  def config
+    ActiveSupport::ConfigurationFile.parse(Rails.root.join('config/recurring.yml')).deep_symbolize_keys
+  end
 
+  test 'every environment schedules jobs that exist, at times that parse' do
     %i[production staging].each do |env|
       tasks = config.fetch(env)
 
@@ -22,6 +24,16 @@ class RecurringScheduleTest < ActiveSupport::TestCase
         assert_kind_of Fugit::Cron, Fugit.parse(task.fetch(:schedule), multi: :fail),
                        "#{env}/#{id} is not scheduled at a time Solid Queue takes"
       end
+    end
+  end
+
+  # Anchors sit at the top level alongside the environments, and for any
+  # environment it does not find there Solid Queue takes the whole file as the
+  # schedule. A task written directly at that level -- rather than inside one --
+  # is picked up, and runs in development and in test, where nobody is looking.
+  test 'nothing at the top level is a task in its own right' do
+    config.each do |key, value|
+      assert_not value.key?(:schedule), "#{key} is scheduled at the top level, which runs it in every environment"
     end
   end
 end


### PR DESCRIPTION
`ReportUncopiedUploadsJob` ran for the first time and named two uploads that had arrived fine: copied in June 2025, blobs let go, and the submission directory removed some time afterwards by somebody working on that filesystem who was not us. It had only the directory to go on, and a directory that is gone reads the same whether it was never filled or tidied away once the submission was dealt with.

## The record moves to the upload

Whether the copy happened was written down on `webui_uploads`, where only a direct upload could see it — so the report could not use it, and an upload gathered from an extraction had nothing written down at all. `uploads.copied_at` is set in `UploadVia#stage_files`, the one place every way of arriving passes through.

That flag was saying two things at once: the files were copied, and the blobs were let go. The second is now asked of the attachments, which answer it however far the purge actually got. The purge is done where the copy is, synchronously, so a storage that will not let go fails the copy and is retried with it rather than quietly leaving blobs no sweep can reach.

**`webui_uploads.copied` is not dropped here.** Kamal runs `db:prepare` when the new container boots while the old one is still serving, and with `partial_inserts` false the old code's INSERT names every column — dropping it would 500 every submission made in that window. It is marked `ignored_columns` and goes in a deploy of its own, which must run this same disk backfill again: a copy the old containers finish after this migration sets the old flag and nothing else.

## Telling files that are gone from files somebody put away

Not by counting. The tidied pile only ever grows, so anything measured against it becomes answer enough on its own one evening and nothing is ever named again. What separates them is what the tidying leaves behind and when it happened: curators clear away the whole submission, and only once they have finished with it, which takes a while. So a submission still standing without an upload's files is the ground moving whenever it happened, and one gone entirely is worth asking about while it is too recent to have been anybody's housekeeping. That is now `VanishedFiles`, which the report was previously blind to by construction.

Nothing is suppressed any more either. Past the point where naming them one at a time is any use they are counted instead of dropped, each kind on its own, so a pile of one is no reason to go quiet about the single upload of another that somebody could still act on. The count is said first, because what carries these away queues them and discards what it cannot keep up with. They are taken oldest first, so an upload nobody has got to yet keeps its place tomorrow.

It no longer runs on staging, where half-finished work is left lying and nobody is going to answer for it.

## Also

`Upload#file_names` asked the directory for everything with a dot in its name, so a file named without one — or with a leading dot — was copied into place and then never mentioned again. Sorted too: the submitter watches that list while the copy runs, and reading the directory back unsorted rearranged it under them at the moment the files landed.

## What this says about the incidents

- **NSUB002724** (uploads 3902/3912) — false positives. `via.updated_at` is under a second after `created_at`, in June 2025: a normal copy. Silent from here.
- **NSUB001289** (upload 1853) — a genuine, permanent loss. Still named every night, correctly.
- **NSUB003450** (uploads 5115/5116) — the copy crashed between the move and the purge. `trim_annotation_fields!` ran after the rename back then and raised `NoMethodError` on a blank line; the guard arrived three weeks later in 033e487. Confirmed on disk: those two directories hold a blank line and the six later ones do not. They keep being reported as `UnreleasedBlobs` until their blobs are released by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)