### PR TITLE
Sweep up what a copy was carrying when it was stopped

### DIFF
--- a/app/jobs/purge_abandoned_staging_job.rb
+++ b/app/jobs/purge_abandoned_staging_job.rb
@@ -1,0 +1,71 @@
+require 'find'
+
+class PurgeAbandonedStagingJob < ApplicationJob
+  # Left behind and will not go away. Said once at the end rather than raised
+  # where it happens, so that one directory that will not go does not keep the
+  # others from going.
+  class StuckStaging < StandardError; end
+
+  # What stage_files names its directories. Nothing else has any business being
+  # in there, but this is a job whose whole trade is removing directories: it
+  # takes only the ones it can account for.
+  STAGED = /\ANSUB\d+-\d+\z/
+
+  # How long a staging directory is left alone. A copy that is running touches
+  # its own as it writes, so this is not a race with one in progress: it is how
+  # long after a copy stops writing we are prepared to believe it is not coming
+  # back. Generous, because a submission can be a great many gigabytes.
+  RETENTION = 1.day
+
+  queue_as :default
+
+  # A copy clears up after itself, but only when it is given the chance: a
+  # container killed part way through leaves the files it had gathered so far
+  # where nothing will ever look at them again, and the next attempt gathers its
+  # own. Five of those had been sitting there since March, holding 82MB of
+  # copies of files that had long since reached their submissions.
+  def perform
+    staging_dir = Submission.staging_dir
+
+    return unless staging_dir.exist?
+
+    stuck = staging_dir.children.select { STAGED.match?(_1.basename.to_s) && abandoned?(_1) }.reject { remove(_1) }
+
+    return if stuck.empty?
+
+    Rails.error.report(
+      StuckStaging.new('what a stopped copy left behind will not go away'),
+      handled: true,
+      context:  {directories: stuck.map(&:to_s)}
+    )
+  end
+
+  private
+
+  def abandoned?(dir)
+    last_touched(dir)&.before?(RETENTION.ago) || false
+  end
+
+  # Asked of everything inside as well as of the directory itself, dot-named
+  # files included. Adding a file is what moves a directory's own time, so one
+  # being filled a byte at a time -- which is what a large copy looks like for
+  # most of its life -- would otherwise read as untouched since it started.
+  #
+  # lstat, so a symlink is asked about itself: following one that points nowhere
+  # raises, and a broken link is no reason to stop looking at the rest. Anything
+  # that goes while we are looking counts as still in use, since the only thing
+  # that takes these away is a copy finishing with one.
+  def last_touched(dir)
+    Find.find(dir.to_s).map { File.lstat(_1).mtime }.max
+  rescue Errno::ENOENT
+    nil
+  end
+
+  # rmtree is rm_rf, which reports nothing at all -- not a missing directory,
+  # which is what we want, and not one it could not remove, which we do.
+  def remove(dir)
+    dir.rmtree
+
+    !dir.exist?
+  end
+end

--- a/app/models/concerns/upload_via.rb
+++ b/app/models/concerns/upload_via.rb
@@ -30,7 +30,7 @@ module UploadVia
       # Named after the upload rather than the directory it is bound for, which
       # is settled while the upload is being made: this runs long afterwards,
       # and asks nothing of what it was settled to be.
-      work = submission.root_dir.join("../.work/#{submission.mass_id}-#{upload.id}")
+      work = Submission.staging_dir.join("#{submission.mass_id}-#{upload.id}")
       work.mkpath
 
       begin

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -27,6 +27,13 @@ class Submission < ApplicationRecord
     @submissions_dir ||= Pathname.new(Rails.application.config_for(:app).submissions_dir!)
   end
 
+  # Where an upload's files are gathered before they are moved into place, off
+  # to one side of the submissions themselves so that a directory half filled is
+  # never anywhere a curator or a submitter is looking.
+  def self.staging_dir
+    submissions_dir.join('.work')
+  end
+
   def root_dir
     Submission.submissions_dir.join(mass_id)
   end

--- a/app/models/working_list.rb
+++ b/app/models/working_list.rb
@@ -1,4 +1,11 @@
 class WorkingList
+  # The submission is listed when it is first sent, so a row that is not there
+  # when another upload arrives means that listing did not happen. Said the same
+  # way every time, and the submission named in the job's own context rather
+  # than in the sentence -- which would otherwise be one thing to answer for per
+  # submission, none of them saying what went wrong.
+  class MissingRow < StandardError; end
+
   def self.instance
     @instance ||= begin
       config = Rails.application.config_for(:working_list)
@@ -48,10 +55,10 @@ class WorkingList
   def update_data_arrival_date(submission)
     row = find_row_number_by_mass_id(submission.mass_id)
 
-    raise submission.mass_id unless row
+    raise MissingRow, 'the working list has no row for this submission' unless row
 
     range = Google::Apis::SheetsV4::ValueRange.new(values: [
-      [to_row(submission).fetch(:data_arrival_date)]
+      [data_arrival_date(submission)]
     ])
 
     Retriable.with_context :google do
@@ -59,6 +66,14 @@ class WorkingList
         value_input_option: 'RAW'
       }
     end
+  end
+
+  # Every directory the submission has been handed files in, which is what the
+  # curator reads as the date the data arrived. Its own method because the row
+  # around it is a dozen more queries and a submission this one is the only part
+  # of that is wanted.
+  def data_arrival_date(submission)
+    submission.uploads.map(&:files_dir_name).join('; ')
   end
 
   def to_row(submission)
@@ -74,11 +89,11 @@ class WorkingList
       other_person:               submission.other_people.order(:position).map(&:email_address_with_name).join('; '),
       dway_account:               submission.user.uid,
       dway_account_email:         submission.user.email,
-      data_arrival_date:          submission.uploads.map(&:files_dir_name).join('; '),
+      data_arrival_date:          data_arrival_date(submission),
       check_start_date:           nil,
       finish_date:                nil,
       sequencer:                  submission.sequencer_text,
-      upload_via:                 submission.uploads.first.via_ident,
+      upload_via:                 submission.uploads.first&.via_ident,
       hup:                        submission.hold_date || 'non-HUP',
       tpa:                        submission.tpa?,
       data_type:                  submission.data_type.upcase,

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,9 +1,18 @@
-# Both sweep up after what a submitter left behind: the files an extraction
-# gathered, and the blobs a direct upload made for an application that was never
-# sent. Overnight, when neither is likely to be in the middle of use, and behind
-# everything else in the queue -- a backlog of them must not keep a submitter's
-# own upload waiting.
+# All three sweep up after something that was left: the files a copy had
+# gathered when it was stopped, the files an extraction gathered for a submitter
+# to look over, and the blobs a direct upload made for an application that was
+# never sent. Overnight, when none of them is likely to be in the middle of use,
+# and behind everything else in the queue -- a backlog of them must not keep a
+# submitter's own upload waiting.
 sweeps: &sweeps
+  # What a copy had gathered when it was stopped part way through. It clears up
+  # after itself when it is given the chance; a container killed mid-copy is not
+  # a chance.
+  purge_abandoned_staging:
+    class: PurgeAbandonedStagingJob
+    priority: 10
+    schedule: at 3:30am every day
+
   purge_extractions:
     class: PurgeExtractionsJob
     priority: 10

--- a/test/jobs/purge_abandoned_staging_job_test.rb
+++ b/test/jobs/purge_abandoned_staging_job_test.rb
@@ -1,0 +1,191 @@
+require 'test_helper'
+require 'find'
+
+class PurgeAbandonedStagingJobTest < ActiveJob::TestCase
+  def staging(name = 'NSUB000001-1', age:, files: {'example.ann' => 'COMMON'})
+    dir = Submission.staging_dir.join(name)
+
+    aged dir, age, files
+  end
+
+  def aged(dir, age, files)
+    dir.mkpath
+
+    files.each do |filename, content|
+      dir.join(filename).dirname.mkpath
+      dir.join(filename).write content
+    end
+
+    Find.find(dir.to_s).each do |path|
+      File.utime age.to_time, age.to_time, path
+    end
+
+    dir
+  end
+
+  test 'what a copy had gathered when it was stopped is let go' do
+    dir = staging(age: 2.days.ago)
+
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_not dir.exist?
+  end
+
+  test 'a copy that is still going is left alone' do
+    dir = staging(age: 1.minute.ago)
+
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_predicate dir, :exist?
+  end
+
+  test 'a copy still writing into a directory it made long ago is left alone' do
+    dir = staging(age: (PurgeAbandonedStagingJob::RETENTION + 1.hour).ago)
+
+    # Adding a file is what moves a directory's own time, so a large copy that
+    # started yesterday and is still writing the file it started with looks
+    # untouched from the outside. What it is writing does not.
+    File.utime Time.current.to_time, Time.current.to_time, dir.join('example.ann')
+
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_predicate dir, :exist?
+  end
+
+  test 'an empty directory from an attempt that got nowhere is let go' do
+    dir = staging(age: (PurgeAbandonedStagingJob::RETENTION + 1.hour).ago, files: {})
+
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_not dir.exist?
+  end
+
+  test 'a copy stages where this sweeps' do
+    extraction = dfast_extractions(:alice_dfast_extraction)
+
+    extraction.working_dir.mkpath
+    extraction.files.create!(name: 'example.ann', dfast_job_id: 'job-1', parsing: false)
+    extraction.working_dir.join('example.ann').write "COMMON\tSUBMITTER\t\tcontact\tAlice Liddell\n"
+
+    upload = submissions(:alice_submission).uploads.create!(via: DfastUpload.new(extraction:), created_at: 1.hour.ago)
+    staged = nil
+
+    FileUtils.stub :cp, ->(source, destination) { staged = destination; FileUtils.copy(source, destination) } do
+      CopySubmissionFilesJob.perform_now upload
+    end
+
+    # A copy clears up after itself, so the only ones left for this to find are
+    # the ones nothing was left running to clear up -- which means nothing ties
+    # the two ends together except that they name the same place. Asked here so
+    # that moving one and not the other is a failure rather than a sweep that
+    # quietly stops sweeping.
+    assert_equal Submission.staging_dir, staged.parent
+  end
+
+  test 'a dot-named file is what the copy was still writing too' do
+    dir = staging(age: 2.days.ago, files: {'.example.ann' => 'COMMON'})
+
+    # Nothing between the submitter and the disk turns a leading dot down, and
+    # a directory's own time does not move for a file being rewritten. If the
+    # only thing in there is invisible to this, a copy that is still going
+    # reads as one that stopped a day ago.
+    File.utime Time.current.to_time, Time.current.to_time, dir.join('.example.ann')
+
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_predicate dir, :exist?
+  end
+
+  test 'a directory below the one being staged is looked into as well' do
+    dir = staging(age: 2.days.ago, files: {'nested/example.ann' => 'COMMON'})
+
+    File.utime Time.current.to_time, Time.current.to_time, dir.join('nested/example.ann')
+
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_predicate dir, :exist?
+  end
+
+  test 'a link pointing nowhere is not a reason to leave a directory standing' do
+    linked = staging('NSUB000001-8', age: 2.days.ago, files: {})
+
+    linked.join('gone').make_symlink 'nowhere'
+
+    [linked, linked.join('gone')].each do |path|
+      File.lutime 2.days.ago.to_time, 2.days.ago.to_time, path
+    end
+
+    # Asked about the link itself rather than about what it points at, which is
+    # not there. A directory holding one would otherwise never look untouched,
+    # and would sit here for good.
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_not linked.exist?
+  end
+
+  test 'one that goes while we are looking at it does not stop the rest' do
+    going     = staging('NSUB000001-6', age: 2.days.ago)
+    abandoned = staging('NSUB000001-7', age: 2.days.ago)
+
+    lstat = File.method(:lstat)
+
+    # The only thing that takes one of these away is a copy finishing with it,
+    # and that happens while this is running. A sweep that stops at its first
+    # casualty looks exactly like one with nothing left to do.
+    File.stub :lstat, ->(path) { raise Errno::ENOENT, path.to_s if path.to_s.start_with?(going.to_s); lstat.call(path) } do
+      PurgeAbandonedStagingJob.perform_now
+    end
+
+    assert_not abandoned.exist?
+  end
+
+  test 'something else that found its way in there is not this to remove' do
+    other = Submission.staging_dir.join('NSUB000001')
+
+    aged other, 2.days.ago, {'example.ann' => 'COMMON'}
+
+    # This is a job whose whole trade is removing directories, so it takes only
+    # the ones it can account for. A submission's own directory is named like
+    # this one, and pointed a level too high that is what it would find.
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_predicate other, :exist?
+  end
+
+  test "a submission's own directory is not something this removes" do
+    submission = submissions(:alice_submission)
+
+    aged submission.root_dir, 2.days.ago, {'20220101-000000/example.ann' => 'COMMON'}
+
+    # Submissions sit untouched for weeks -- curators only clear them away once
+    # they are finished, which is the whole reason the nightly report cannot go
+    # by age alone. Staging is off to one side of them, not among them.
+    assert_not_equal submission.root_dir.dirname, Submission.staging_dir
+    PurgeAbandonedStagingJob.perform_now
+
+    assert_predicate submission.root_dir.join('20220101-000000/example.ann'), :exist?
+  end
+
+  test 'one that will not go away is said out loud' do
+    dir = staging(age: 2.days.ago)
+
+    stuck = capture_error_reports(PurgeAbandonedStagingJob::StuckStaging) {
+      FileUtils.stub :rm_rf, ->(*, **) { } do
+        PurgeAbandonedStagingJob.perform_now
+      end
+    }.sole
+
+    # rm_rf reports nothing at all, so a directory that cannot be removed --
+    # left by a deploy that changed the user we run as, say -- would otherwise
+    # sit there exactly as silently as the ones this job exists to find.
+    assert_equal [dir.to_s], stuck.context.fetch(:directories)
+  end
+
+  test 'nothing having been staged yet is not a failure' do
+    assert_not Submission.staging_dir.exist?
+
+    assert_nothing_raised do
+      PurgeAbandonedStagingJob.perform_now
+    end
+  end
+end

--- a/test/jobs/update_working_list_job_test.rb
+++ b/test/jobs/update_working_list_job_test.rb
@@ -19,11 +19,9 @@ class UpdateWorkingListJobTest < ActiveJob::TestCase
       )
     )
 
-    Upload.create!(
-      submission: @submission,
-      via:        WebuiUpload.new,
-      created_at: '2022-01-02 12:34:56'
-    )
+    ['2022-01-02 12:34:56', '2022-01-05 09:00:00'].each do |created_at|
+      Upload.create!(submission: @submission, via: WebuiUpload.new, created_at:)
+    end
 
     stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token').to_return(
       headers: {content_type: 'application/json'},
@@ -41,11 +39,30 @@ class UpdateWorkingListJobTest < ActiveJob::TestCase
     stub_request(:put, 'https://sheets.googleapis.com/v4/spreadsheets/WORKING_LIST_SHEET_ID/values/WORKING_LIST_SHEET_NAME!L101').with(query: hash_including({}))
   end
 
+  # A submission is handed files more than once, and the cell holds every
+  # directory it has been handed them in.
   test 'updates the data_arrival_date cell in the working list' do
     UpdateWorkingListJob.perform_now @submission
 
     assert_requested :put, 'https://sheets.googleapis.com/v4/spreadsheets/WORKING_LIST_SHEET_ID/values/WORKING_LIST_SHEET_NAME!L101',
-      body:  {values: [['20220102-123456']]},
+      body:  {values: [['20220102-123456; 20220105-090000']]},
       query: {valueInputOption: 'RAW'}
+  end
+
+  test 'a submission the working list has never heard of' do
+    stub_request(:get, 'https://sheets.googleapis.com/v4/spreadsheets/WORKING_LIST_SHEET_ID/values/WORKING_LIST_SHEET_NAME!A:A').to_return(
+      headers: {content_type: 'application/json'},
+      body:    JSON.generate(values: [['NSUB000001']])
+    )
+
+    # It is listed when it is first sent, so a row that is not there when
+    # another upload arrives means that listing did not happen. Said the same
+    # way whichever submission it is: a sentence that named it would be one
+    # thing to answer for per submission, none of them saying what went wrong.
+    error = assert_raises WorkingList::MissingRow do
+      UpdateWorkingListJob.perform_now @submission
+    end
+
+    assert_equal 'the working list has no row for this submission', error.message
   end
 end

--- a/test/models/extraction_upload_test.rb
+++ b/test/models/extraction_upload_test.rb
@@ -95,7 +95,7 @@ class ExtractionUploadTest < ActiveSupport::TestCase
 
     # Nor aside, where the half of them that were copied would be moved into
     # place along with the next attempt's own.
-    assert_empty Dir.glob('*', base: submission.root_dir.join('../.work'))
+    assert_empty Dir.glob('*', base: Submission.staging_dir)
   end
 
   private

--- a/test/models/working_list_test.rb
+++ b/test/models/working_list_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class WorkingListTest < ActiveSupport::TestCase
+  test 'a submission whose uploads have all been taken away still makes a row' do
+    submission = submissions(:alice_submission)
+
+    submission.uploads.destroy_all
+
+    # The row is a dozen queries about a submission, and one of them used to be
+    # asked of an upload that was assumed to be there. Nothing sends a
+    # submission with no uploads, but nothing stops one being left that way
+    # either, and a sheet write is not where that should first be noticed.
+    row = WorkingList.instance.to_row(submission.reload)
+
+    assert_equal submission.mass_id, row.fetch(:mass_id)
+    assert_nil   row.fetch(:upload_via)
+    assert_equal '', row.fetch(:data_arrival_date)
+  end
+end


### PR DESCRIPTION
Two things the MSSFORM-6G/6H investigation turned up that were not the report job itself.

## `.work` accumulates

An upload's files are gathered in `submissions_dir/.work/<mass_id>-<upload_id>` and moved into place in one rename, and `UploadVia#stage_files` clears that directory up in an `ensure`. A container killed part way through is not a chance to run an `ensure`. Five of those had been sitting there since March, holding 82MB of copies of files that had long since reached their submissions.

The new sweep takes a staging directory nothing has written to for a day. That question is asked of everything inside as well as of the directory itself, dot-named files included — adding a file is what moves a directory's own time, so one being filled a byte at a time, which is what a large copy looks like for most of its life, would otherwise read as untouched since it started. With `lstat`, so a link pointing nowhere is not a directory that can never be swept, and anything that goes while we are looking counts as in use, since the only thing that takes these away is a copy finishing with one.

It takes only directories it can account for by name. A submission's own directory sits one level up and is only ever cleared away by a curator who has finished with it, which is the whole reason `ReportUncopiedUploadsJob` cannot go by age alone. And `rm_rf` reports nothing at all, so what it could not remove is said out loud rather than left to sit exactly as silently as what this was written to find.

Where staging happens is now named in one place rather than walked back out of a submission's own directory (`submission.root_dir.join("../.work/…")`), so moving it cannot move it out from under the sweep. A test ties the two ends together.

## `raise submission.mass_id`

A sentence that is only ever a mass ID tells whoever finds it nothing, and it is a different sentence for every submission — so Sentry made a separate issue of each and none accumulated into anything anybody would notice. The submission is in the job's own context either way. Found by hitting it: NSUB001289 is old enough not to be in the sheet at all.

While there: writing that one cell was building the whole row first, a dozen queries about the submission of which one was wanted. The arrival date is its own method now, which also takes the contact person, the user, and the other people out of a code path that has no business failing on their account. And the row no longer assumes a submission has an upload.

## Not included

I had proposed reporting Solid Queue's failed executions nightly. It is unnecessary: `sentry-rails`' ActiveJob extension already captures every job exception. The March 2026 failures were invisible because the Sentry DSN was not configured until #1521 in June, not because the failed list is structurally unwatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)