### PR TITLE
Drop the flag whose two meanings have both moved

### DIFF
--- a/app/models/webui_upload.rb
+++ b/app/models/webui_upload.rb
@@ -1,13 +1,6 @@
 class WebuiUpload < ApplicationRecord
   include UploadVia
 
-  # Said two things at once and could only be seen from here, so both moved:
-  # whether the files were copied is on the upload now, and whether the blobs
-  # were let go is asked of the attachments. Ignored rather than dropped, so
-  # that the containers still serving during the deploy that stops writing it
-  # are not inserting a column this one has taken away.
-  self.ignored_columns = %i[copied]
-
   has_many_attached :files
 
   # The signed IDs come from a direct upload this submitter just made, so an

--- a/db/migrate/20260823213046_drop_copied_from_webui_uploads.rb
+++ b/db/migrate/20260823213046_drop_copied_from_webui_uploads.rb
@@ -1,0 +1,71 @@
+class DropCopiedFromWebuiUploads < ActiveRecord::Migration[8.1]
+  # What this said moved to uploads.copied_at, where every way of arriving can
+  # say it. The column stayed behind for one deploy because the containers still
+  # serving through that one were inserting rows that named it; nothing reads or
+  # writes it now.
+  #
+  # The backfill runs again first, and has to. A copy those containers finished
+  # after the last one ran set this flag and nothing else, so the upload it
+  # belongs to is sitting here with no copied_at -- which reads as copied for
+  # exactly as long as its directory is there, and turns into a permanent false
+  # positive the day a curator clears the submission away. Dropping the column
+  # takes the last evidence of it with it.
+  #
+  # Written out again rather than shared with the migration that first ran it:
+  # what a migration did is a matter of record, and a record is no use if it
+  # changes underneath.
+  def up
+    execute <<~SQL.squish
+      UPDATE uploads SET copied_at = webui_uploads.updated_at
+      FROM webui_uploads
+      WHERE uploads.via_type = 'WebuiUpload'
+        AND uploads.via_id = webui_uploads.id
+        AND webui_uploads.copied
+        AND uploads.copied_at IS NULL
+    SQL
+
+    backfill_from_disk
+
+    remove_column :webui_uploads, :copied
+  end
+
+  def down
+    add_column :webui_uploads, :copied, :boolean, default: false, null: false
+
+    execute <<~SQL.squish
+      UPDATE webui_uploads SET copied = true
+      FROM uploads
+      WHERE uploads.via_type = 'WebuiUpload'
+        AND uploads.via_id = webui_uploads.id
+        AND uploads.copied_at IS NOT NULL
+    SQL
+  end
+
+  private
+
+  # Every other way of arriving says so only by having a directory. Nothing to
+  # read is not a reason to declare them all uncopied: the directory is still
+  # what Upload#copied? falls back to, so they lose nothing by being missed.
+  def backfill_from_disk
+    root = Pathname.new(Rails.application.config_for(:app).submissions_dir!)
+
+    return unless root.exist?
+
+    rows = select_all(<<~SQL.squish)
+      SELECT uploads.id, uploads.files_dir_name, submissions.mass_id
+      FROM uploads
+      JOIN submissions ON submissions.id = uploads.submission_id
+      WHERE uploads.copied_at IS NULL
+    SQL
+
+    copied = rows.filter_map {
+      Integer(_1['id']) if root.join(_1['mass_id'], _1['files_dir_name']).exist?
+    }
+
+    copied.each_slice(1_000) do |slice|
+      execute "UPDATE uploads SET copied_at = updated_at WHERE id IN (#{slice.join(', ')})"
+    end
+
+    say "read #{copied.size} uploads off the disk", true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_23_143111) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_213046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -185,7 +185,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_143111) do
   end
 
   create_table "webui_uploads", force: :cascade do |t|
-    t.boolean "copied", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
The second half of #1662's two-step. Whether a direct upload's files had been copied, and whether its blobs had been let go, were one boolean on `webui_uploads`. The first is `uploads.copied_at` now, where every way of arriving can say it; the second is asked of the attachments, which answer it however far the purge got. The column stayed behind for one deploy because the containers still serving through that one were inserting rows that named it.

## The backfill runs again before it goes, and has to

A copy those containers finished after #1662's migration ran set the flag and nothing else, so the upload it belongs to would be sitting here with no `copied_at` — which reads as copied for exactly as long as its directory is there, and becomes a permanent false positive the day a curator clears the submission away. That is what this whole change was made to stop, and dropping the column takes the last evidence of it along too.

Production has none of those (checked: the deploy landed at a quiet hour), so this run is insurance.

It is written out again rather than shared with #1662's migration: what a migration did is a matter of record, and a record is no use if it changes underneath.

## Deploying and rolling back

Safe in the deploy window: #1662's code carries `self.ignored_columns = %i[copied]`, which makes Rails name its columns explicitly, so an old container's `SELECT`/`INSERT`/`UPDATE` on `webui_uploads` never mentions the dropped column.

**Rolling back past #1662 needs `bin/rails db:rollback` first.** Kamal swaps the image without migrating down, and pre-#1662 code fails on the missing column in a quiet way: `POST /api/submissions/:id/uploads` succeeds and the submitter gets their confirmation mail, then `CopySubmissionFilesJob` dies on `return if copied?` with a `NoMethodError` that is not in its `retry_on` list. Files never copied, submitter told otherwise. The `down` here restores the column from `copied_at` correctly; it just is not automatic. Rolling back to the #1662 image itself is fine either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)