### PR TITLE
Bump the ember-intl packages together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
       glint:
         patterns:
           - '@glint/*'
+
+      # ember-intl and the @ember-intl/* packages divide the work of loading
+      # translations between them, so a major bump of one without the others
+      # leaves the app unable to read its own translation files.
+      ember-intl:
+        patterns:
+          - 'ember-intl'
+          - '@ember-intl/*'
     ignore:
       # Babel 8 requires the whole @babel/* graph to move together, but the
       # Ember build toolchain (ember-cli-babel, broccoli-babel-transpiler)


### PR DESCRIPTION
Follow-up to #1678.

`ember-intl` v9 handed the flattening of translation files to the packages that load them (`@ember-intl/vite` here), so the two only work as a pair. Dependabot bumped `ember-intl` alone in #1672, which left the app unable to resolve keys it had loaded itself — grouping them means the next major arrives as one PR that can actually be evaluated.

The pattern list covers `@ember-intl/lint` and `@ember-intl/v1-compat` too, in case either is ever added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqkzDuMHvson2uvSUh4WSG